### PR TITLE
fix: prefer Claude.icns over electron.icns

### DIFF
--- a/scripts/fetch-and-extract.sh
+++ b/scripts/fetch-and-extract.sh
@@ -310,10 +310,14 @@ log "Electron version: ${ELECTRON_VERSION:-unknown}"
 # Output: packaging/icons/claude-{16,32,48,64,128,256,512}.png
 # ---------------------------------------------------------------------------
 RESOURCES_DIR="$(dirname "$ASAR_SRC")"
-# Search case-insensitively; fall back to the whole extract tree.
-ICNS_FILE=$(find "$RESOURCES_DIR" -iname "*.icns" | head -1 || true)
+# Prefer the app icon (claude.icns / Claude.icns) over generic electron.icns.
+# Search order: exact app name → any non-electron icns in Resources → whole tree.
+ICNS_FILE=$(find "$RESOURCES_DIR" -iname "claude.icns" | head -1 || true)
 if [[ -z "$ICNS_FILE" ]]; then
-  ICNS_FILE=$(find "$EXTRACT_DIR" -iname "*.icns" | head -1 || true)
+  ICNS_FILE=$(find "$RESOURCES_DIR" -iname "*.icns" ! -iname "electron.icns" | head -1 || true)
+fi
+if [[ -z "$ICNS_FILE" ]]; then
+  ICNS_FILE=$(find "$EXTRACT_DIR" -iname "*.icns" ! -iname "electron.icns" | head -1 || true)
 fi
 
 ICONS_DIR="$REPO_DIR/packaging/icons"


### PR DESCRIPTION
The broad `*.icns` search was matching `electron.icns` before `Claude.icns`.
Now searches in priority order: `claude.icns` → any non-electron icns → full tree fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)