### PR TITLE
fix(ci): fix build crash and broken DNF repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -244,6 +244,9 @@ jobs:
             git -C /tmp/gh-pages commit --allow-empty -m "Initialize gh-pages"
           fi
 
+          # Disable Jekyll so GitHub Pages serves files as-is (no HTML wrapping).
+          touch /tmp/gh-pages/.nojekyll
+
           # Generate repo metadata in a staging directory.
           # The RPM itself is NOT stored in gh-pages (exceeds GitHub's 100 MB
           # file-size limit).  Instead, --location-prefix tells dnf to fetch


### PR DESCRIPTION
## Summary
- **CI crash fix**: The RPM (~128 MB) was being pushed to `gh-pages`, exceeding GitHub's 100 MB file size limit. Now uses `createrepo_c --location-prefix` to generate metadata pointing to GitHub Releases, and only pushes `repodata/` (a few KB) to `gh-pages`.
- **DNF repo fix**: GitHub Pages runs Jekyll by default, wrapping the `.repo` file in HTML — causing `dnf install` to fail with "Missing section header on line 1". Adds `.nojekyll` to disable Jekyll.

## Test plan
- [ ] Re-run the CI workflow on `main` after merge
- [ ] Verify `gh-pages` push succeeds (no 100 MB limit error)
- [ ] Verify `curl https://stslex.github.io/claude-desktop-linux/claude-desktop.repo` returns raw INI content
- [ ] Verify `sudo dnf install claude-desktop` resolves the package from GitHub Releases

https://claude.ai/code/session_014FfdmDQ93TjUNaigGcRfm5