### PR TITLE
Move repack number computation earlier in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,9 +84,33 @@ jobs:
           path: ${{ env.BUILD_DIR }}/patch-*.log
           if-no-files-found: warn
 
+      - name: Compute repack number
+        id: repack
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION:  ${{ steps.ver.outputs.version }}
+        run: |
+          # Count existing repacks for this exact Claude version.
+          REPACK=0
+          if [[ "${{ github.ref }}" == "refs/heads/main" ]] || \
+             [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.release }}" == "true" ]]; then
+            EXISTING="$(gh release list --repo "${{ github.repository }}" \
+              --limit 200 --json tagName --jq '.[].tagName' 2>/dev/null || true)"
+            while IFS= read -r tag; do
+              if [[ "$tag" =~ ^v${VERSION}-repack-([0-9]+)$ ]]; then
+                N="${BASH_REMATCH[1]}"
+                (( N + 1 > REPACK )) && REPACK=$(( N + 1 ))
+              fi
+            done <<< "$EXISTING"
+          fi
+          echo "num=${REPACK}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${VERSION}-repack-${REPACK}" >> "$GITHUB_OUTPUT"
+          echo "Computed repack number: ${REPACK}"
+
       - name: build-packages
         env:
           KEEP_BUILD_DIR: '1'   # preserve BUILD_DIR so electron-cache can be saved
+          REPACK_NUM: ${{ steps.repack.outputs.num }}
         run: bash scripts/build-packages.sh
 
       # -----------------------------------------------------------------------
@@ -106,32 +130,10 @@ jobs:
       #   • workflow_dispatch with release=true  → release
       #   • push to dev / PR  → skip
       # -----------------------------------------------------------------------
-      - name: Compute repack number and release tag
-        id: repack
+      - name: Rename assets to include repack suffix
         if: >
           github.ref == 'refs/heads/main' ||
           (github.event_name == 'workflow_dispatch' && inputs.release == true)
-        env:
-          GH_TOKEN: ${{ github.token }}
-          VERSION:  ${{ steps.ver.outputs.version }}
-        run: |
-          # Count existing repacks for this exact Claude version.
-          REPACK=0
-          EXISTING="$(gh release list --repo "${{ github.repository }}" \
-            --limit 200 --json tagName --jq '.[].tagName' 2>/dev/null || true)"
-          while IFS= read -r tag; do
-            if [[ "$tag" =~ ^v${VERSION}-repack-([0-9]+)$ ]]; then
-              N="${BASH_REMATCH[1]}"
-              (( N + 1 > REPACK )) && REPACK=$(( N + 1 ))
-            fi
-          done <<< "$EXISTING"
-          RELEASE_TAG="v${VERSION}-repack-${REPACK}"
-          echo "num=${REPACK}"          >> "$GITHUB_OUTPUT"
-          echo "tag=${RELEASE_TAG}"     >> "$GITHUB_OUTPUT"
-          echo "Computed release tag: ${RELEASE_TAG}"
-
-      - name: Rename assets to include repack suffix
-        if: steps.repack.outcome == 'success'
         env:
           VERSION: ${{ steps.ver.outputs.version }}
           REPACK:  ${{ steps.repack.outputs.num }}
@@ -155,7 +157,9 @@ jobs:
 
       - name: Compute checksums for release notes
         id: sums
-        if: steps.repack.outcome == 'success'
+        if: >
+          github.ref == 'refs/heads/main' ||
+          (github.event_name == 'workflow_dispatch' && inputs.release == true)
         env:
           VERSION: ${{ steps.ver.outputs.version }}
           REPACK:  ${{ steps.repack.outputs.num }}
@@ -167,7 +171,9 @@ jobs:
           echo "appimage=${AI_SHA}"   >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
-        if: steps.repack.outcome == 'success'
+        if: >
+          github.ref == 'refs/heads/main' ||
+          (github.event_name == 'workflow_dispatch' && inputs.release == true)
         env:
           GH_TOKEN:  ${{ github.token }}
           VERSION:   ${{ steps.ver.outputs.version }}
@@ -222,7 +228,9 @@ jobs:
       #   Users add the repo once via the .repo file at the Pages URL.
       # -----------------------------------------------------------------------
       - name: Update DNF repository on GitHub Pages
-        if: steps.repack.outcome == 'success'
+        if: >
+          github.ref == 'refs/heads/main' ||
+          (github.event_name == 'workflow_dispatch' && inputs.release == true)
         env:
           VERSION: ${{ steps.ver.outputs.version }}
           REPACK:  ${{ steps.repack.outputs.num }}

--- a/packaging/claude-desktop.spec
+++ b/packaging/claude-desktop.spec
@@ -1,10 +1,11 @@
 # Version may be passed via --define "_version <ver>".
 # Falls back to reading %{_builddir}/VERSION at spec-parse time.
 %{!?_version: %global _version %(cat %{_builddir}/VERSION 2>/dev/null || echo 0.0.0)}
+%{!?_repack:  %global _repack  0}
 
 Name:           claude-desktop
 Version:        %{_version}
-Release:        1%{?dist}
+Release:        %{_repack}%{?dist}
 Summary:        Claude Desktop for Linux (unofficial rebuild)
 License:        Proprietary
 URL:            https://github.com/your-org/claude-desktop-linux

--- a/scripts/build-packages.sh
+++ b/scripts/build-packages.sh
@@ -63,7 +63,7 @@ mkdir -p "$OUTPUT_DIR"
 # ---------------------------------------------------------------------------
 log "--- RPM ---"
 RPM_OK=false
-if BUILD_DIR="$BUILD_DIR" OUTPUT_DIR="$OUTPUT_DIR" "$SCRIPT_DIR/build-rpm.sh"; then
+if BUILD_DIR="$BUILD_DIR" OUTPUT_DIR="$OUTPUT_DIR" REPACK_NUM="${REPACK_NUM:-0}" "$SCRIPT_DIR/build-rpm.sh"; then
     RPM_OK=true
     log "RPM build succeeded."
 else

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -119,9 +119,13 @@ cp "$REPO_DIR/packaging/claude-desktop.spec" "$RPM_ROOT/SPECS/claude-desktop.spe
 # ---------------------------------------------------------------------------
 log "Running rpmbuild $VERSION ..."
 
+REPACK_NUM="${REPACK_NUM:-0}"
+log "Repack       : $REPACK_NUM"
+
 RPMBUILD_ARGS=(
     --define "_topdir $RPM_ROOT"
     --define "_version $VERSION"
+    --define "_repack $REPACK_NUM"
     -bb "$RPM_ROOT/SPECS/claude-desktop.spec"
 )
 


### PR DESCRIPTION
## Summary
Refactored the GitHub Actions workflow to compute the repack number earlier in the build process, making it available during the package build phase rather than only during the release phase.

## Key Changes
- **Moved repack computation**: Relocated the "Compute repack number" step from the release section to immediately after version detection, before the `build-packages` step
- **Pass repack to build scripts**: Added `REPACK_NUM` environment variable to the `build-packages.sh` invocation, allowing it to be used during RPM package building
- **Updated RPM spec**: Modified `claude-desktop.spec` to accept a `_repack` macro parameter and use it in the Release field instead of hardcoded "1"
- **Updated build-rpm.sh**: Added support for `REPACK_NUM` environment variable with a default fallback to 0, and pass it to rpmbuild via the `_repack` macro
- **Simplified conditional logic**: Replaced `steps.repack.outcome == 'success'` conditions with explicit branch/event checks in subsequent steps for clarity and consistency

## Implementation Details
- The repack number is now computed once and reused throughout the workflow via step outputs
- RPM packages will now include the repack number in their Release field (e.g., `Release: 2%{?dist}` for repack 2)
- The computation logic remains unchanged—it counts existing releases matching the pattern `v{VERSION}-repack-{N}` and increments accordingly
- All conditional steps that depend on the repack computation now use explicit condition checks instead of relying on step outcome

https://claude.ai/code/session_01P3capJm8zL5V5kr8UP5BUa