### PR TITLE
Add liboss4-salsa-asound2 conflict to Debian package metadata

### DIFF
--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -215,6 +215,7 @@ Architecture: amd64
 Maintainer: Claude Desktop Linux <claude-desktop-linux@users.noreply.github.com>
 Installed-Size: ${INSTALLED_SIZE}
 Depends: bash, xdg-utils, libasound2 | libasound2t64, libatk-bridge2.0-0 | libatk-bridge2.0-0t64, libatk1.0-0 | libatk1.0-0t64, libcairo2, libcups2 | libcups2t64, libdbus-1-3, libdrm2, libexpat1, libgbm1, libglib2.0-0 | libglib2.0-0t64, libgtk-3-0 | libgtk-3-0t64, libnspr4, libnss3, libpango-1.0-0, libx11-6, libxcb1, libxcomposite1, libxdamage1, libxext6, libxfixes3, libxkbcommon0, libxrandr2
+Conflicts: liboss4-salsa-asound2
 Recommends: bubblewrap
 Section: net
 Priority: optional


### PR DESCRIPTION
## Summary
Added a package conflict declaration to the Debian package control file to prevent installation alongside an incompatible audio library.

## Changes
- Added `Conflicts: liboss4-salsa-asound2` to the Debian package metadata in `scripts/build-deb.sh`

## Details
This change declares a conflict with the `liboss4-salsa-asound2` package in the generated Debian control file. This prevents the Claude Desktop Linux package from being installed simultaneously with this incompatible audio library, which could cause runtime issues or library conflicts. The package manager will now warn users or prevent installation if both packages would be present on the system.

https://claude.ai/code/session_019swLNy4abk9omJ4hxgjNsZ