### PR TITLE
Fix tar archive to include versioned directory in package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -369,7 +369,7 @@ jobs:
           bubblewrap: sandboxed Cowork sessions
           DESC_EOF
 
-              tar -czf "$PACMAN_DIR/claude-desktop.db.tar.gz" -C "$DB_STAGING" .
+              tar -czf "$PACMAN_DIR/claude-desktop.db.tar.gz" -C "$DB_STAGING" "claude-desktop-${VERSION}-${REPACK}"
               rm -rf "$DB_STAGING"
             fi
 


### PR DESCRIPTION
## Summary
Updated the tar command in the build workflow to properly include the versioned directory structure when creating the claude-desktop database package archive.

## Key Changes
- Modified the tar command to explicitly include `claude-desktop-${VERSION}-${REPACK}` as the source path instead of using `.` (current directory)
- This ensures the archive contains the properly versioned directory structure rather than just the contents of the staging directory

## Implementation Details
The change affects the pacman database package creation step in the GitHub Actions build workflow. By specifying the exact directory name with version and repack information, the resulting tar.gz archive will maintain the correct directory hierarchy when extracted, preventing potential installation or extraction issues.

https://claude.ai/code/session_016zTCq9fKoqEfRG8RVvJn4G