### PR TITLE
Improve Linux app patching: add fallback icon and shell env worker fix

### DIFF
--- a/patches/native-frame.js
+++ b/patches/native-frame.js
@@ -4,8 +4,8 @@
  *
  * Patches BrowserWindow and Tray for Linux compatibility:
  *
- * 1. BrowserWindow: forces native OS window decorations (frame:true) and sets
- *    the window icon so it appears in title bars, taskbars, and alt-tab.
+ * 1. BrowserWindow: sets the window icon so it appears in title bars,
+ *    taskbars, and alt-tab.
  *
  * 2. Tray: replaces the macOS-specific tray icon (which resolves to nothing on
  *    Linux, showing three dots) with the Claude icon, and wires up a click
@@ -132,14 +132,7 @@ if (!global[INIT_SYM] && process.type === 'browser') {
     // Patch BrowserWindow
     // ---------------------------------------------------------------------
     function patchBrowserWindowOptions(options) {
-      const patched = Object.assign({}, options, {
-        frame: true,
-        transparent: false,
-      });
-      // titleBarStyle / titleBarOverlay are macOS-specific and conflict with
-      // frame:true on Linux — drop them so the WM draws a standard title bar.
-      delete patched.titleBarStyle;
-      delete patched.titleBarOverlay;
+      const patched = Object.assign({}, options);
       // Set the window icon if we have one and the caller didn't set one.
       if (appIcon && !patched.icon) {
         patched.icon = appIcon;
@@ -150,7 +143,7 @@ if (!global[INIT_SYM] && process.type === 'browser') {
     const PatchedBrowserWindow = new Proxy(OrigBrowserWindow, {
       construct(Target, [options = {}, ...rest]) {
         const patched = patchBrowserWindowOptions(options);
-        log('BrowserWindow construct intercepted: frame=true, icon=' + (patched.icon ? 'set' : 'none'));
+        log('BrowserWindow construct intercepted: icon=' + (patched.icon ? 'set' : 'none'));
         return Reflect.construct(Target, [patched, ...rest], Target);
       },
     });
@@ -261,10 +254,6 @@ if (!global[INIT_SYM] && process.type === 'browser') {
           if (appIcon) {
             win.setIcon(appIcon);
           }
-          // Remove any vibrancy/transparency that the macOS code sets.
-          if (typeof win.setVibrancy === 'function') {
-            try { win.setVibrancy(null); } catch (_) {}
-          }
         } catch (e) {
           log(`browser-window-created handler error: ${e.message}`);
         }
@@ -282,7 +271,7 @@ if (!global[INIT_SYM] && process.type === 'browser') {
       }
     }
 
-    log('Patches installed: BrowserWindow(frame=true, icon=' + (appIcon ? 'set' : 'none') +
+    log('Patches installed: BrowserWindow(icon=' + (appIcon ? 'set' : 'none') +
         '), Tray(icon=' + (trayIcon ? 'set' : 'none') + ', click=handler)');
   } catch (e) {
     process.stderr.write(`[native-frame] setup failed: ${e.message}\n${e.stack}\n`);

--- a/patches/native-frame.js
+++ b/patches/native-frame.js
@@ -12,7 +12,8 @@
  *    handler to show/focus the main window.
  *
  * Icons are resolved in order: system-installed (RPM/DEB/pacman), then the
- * PNG/SVG bundled inside the ASAR by patch-cowork.sh as a fallback.
+ * PNG/SVG bundled inside the ASAR by patch-cowork.sh, then a programmatic
+ * fallback as a last resort.
  *
  * Injected at the top of the main-process bundle by patch-cowork.sh so it runs
  * before the app's BrowserWindow/Tray creation code.
@@ -28,7 +29,11 @@ if (!global[INIT_SYM] && process.type === 'browser') {
     const electron = require('electron');
     const OrigBrowserWindow = electron.BrowserWindow;
     const OrigTray = electron.Tray;
-    const debug = process.env.DEBUG;
+    const log = (msg) => process.stderr.write(`[native-frame] ${msg}\n`);
+
+    // ---------------------------------------------------------------------
+    // Icon resolution
+    // ---------------------------------------------------------------------
 
     // Helper: try to load a nativeImage from a path, return null on failure.
     function tryLoadIcon(iconPath) {
@@ -36,25 +41,46 @@ if (!global[INIT_SYM] && process.type === 'browser') {
         if (fs.existsSync(iconPath)) {
           const img = electron.nativeImage.createFromPath(iconPath);
           if (!img.isEmpty()) {
-            if (debug) process.stderr.write(`[native-frame] Loaded icon: ${iconPath}\n`);
+            log(`Loaded icon: ${iconPath}`);
             return img;
           }
+          log(`Icon file exists but loaded as empty: ${iconPath}`);
         }
-      } catch (_) {
-        // ignore and try next
+      } catch (e) {
+        log(`Failed to load icon ${iconPath}: ${e.message}`);
       }
       return null;
     }
 
-    // Resolve icon: prefer system-installed icons (from RPM/DEB/pacman packages),
-    // then fall back to the icon bundled inside the ASAR by patch-cowork.sh.
+    // Helper: create a minimal fallback icon programmatically.
+    // This is a small orange circle with a dark center — recognizable as Claude
+    // even at tray sizes — embedded as a base64-encoded 32x32 PNG.
+    function createFallbackIcon() {
+      try {
+        const dataUrl = 'data:image/png;base64,' +
+          'iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAhElEQVR4nO3T7Q2AMAhF' +
+          '0c7BnK7kRu6jA1QtH+9RGiXh9z0paWv/BOfYtzM1pt1pYTgkEg8jEHE3Ahk3Ixhx' +
+          'NYIZVyGmAjLir4ilACLSbRrgLm5F1ANEnx9yhm+fYKlfgNiagCzEY7wEgI0YxpkI' +
+          'dZyBMMeRCHccgQjHvRBoeIRKizHmAuWItoSnykYjAAAAAElFTkSuQmCC';
+        const img = electron.nativeImage.createFromDataURL(dataUrl);
+        if (!img.isEmpty()) {
+          log('Created programmatic fallback icon');
+          return img;
+        }
+      } catch (e) {
+        log(`Fallback icon creation failed: ${e.message}`);
+      }
+      return null;
+    }
+
     let appIcon = null;
 
-    // 1. System-installed icons (highest resolution first).
+    // 1. System-installed icons (highest resolution first, then scalable SVG).
     const systemPaths = [
       '/usr/share/icons/hicolor/512x512/apps/claude-desktop.png',
       '/usr/share/icons/hicolor/256x256/apps/claude-desktop.png',
       '/usr/share/icons/hicolor/128x128/apps/claude-desktop.png',
+      '/usr/share/icons/hicolor/scalable/apps/claude-desktop.svg',
     ];
     for (const iconPath of systemPaths) {
       appIcon = tryLoadIcon(iconPath);
@@ -73,8 +99,12 @@ if (!global[INIT_SYM] && process.type === 'browser') {
       }
     }
 
+    // 3. Programmatic fallback — ensures we always have SOME icon.
+    if (!appIcon) {
+      appIcon = createFallbackIcon();
+    }
+
     // Tray icons should be smaller (typically 16-24px on Linux).
-    // Resize the app icon for the tray, or try to load a smaller system icon.
     let trayIcon = null;
     if (appIcon) {
       const smallSystemPaths = [
@@ -87,83 +117,97 @@ if (!global[INIT_SYM] && process.type === 'browser') {
         if (trayIcon) break;
       }
       if (!trayIcon) {
-        // Resize the app icon to a tray-appropriate size.
-        trayIcon = appIcon.resize({ width: 32, height: 32 });
+        try {
+          trayIcon = appIcon.resize({ width: 32, height: 32 });
+        } catch (e) {
+          log(`Failed to resize app icon for tray: ${e.message}`);
+          trayIcon = appIcon; // use full-size as fallback
+        }
       }
     }
 
-    // -------------------------------------------------------------------------
+    log(`Icon resolved: app=${appIcon ? 'yes' : 'none'}, tray=${trayIcon ? 'yes' : 'none'}`);
+
+    // ---------------------------------------------------------------------
     // Patch BrowserWindow
-    // -------------------------------------------------------------------------
+    // ---------------------------------------------------------------------
+    function patchBrowserWindowOptions(options) {
+      const patched = Object.assign({}, options, {
+        frame: true,
+        transparent: false,
+      });
+      // titleBarStyle / titleBarOverlay are macOS-specific and conflict with
+      // frame:true on Linux — drop them so the WM draws a standard title bar.
+      delete patched.titleBarStyle;
+      delete patched.titleBarOverlay;
+      // Set the window icon if we have one and the caller didn't set one.
+      if (appIcon && !patched.icon) {
+        patched.icon = appIcon;
+      }
+      return patched;
+    }
+
     const PatchedBrowserWindow = new Proxy(OrigBrowserWindow, {
       construct(Target, [options = {}, ...rest]) {
-        const patched = Object.assign({}, options, {
-          frame: true,
-          transparent: false,
-        });
-        // titleBarStyle / titleBarOverlay are macOS-specific and conflict with
-        // frame:true on Linux — drop them so the WM draws a standard title bar.
-        delete patched.titleBarStyle;
-        delete patched.titleBarOverlay;
-        // Set the window icon if we have one and the caller didn't set one.
-        if (appIcon && !patched.icon) {
-          patched.icon = appIcon;
-        }
+        const patched = patchBrowserWindowOptions(options);
+        log('BrowserWindow construct intercepted: frame=true, icon=' + (patched.icon ? 'set' : 'none'));
         return Reflect.construct(Target, [patched, ...rest], Target);
       },
     });
 
-    // -------------------------------------------------------------------------
+    // Copy static properties and prototype so PatchedBrowserWindow passes
+    // instanceof checks and static method access (e.g. getAllWindows).
+    Object.setPrototypeOf(PatchedBrowserWindow, OrigBrowserWindow);
+    PatchedBrowserWindow.prototype = OrigBrowserWindow.prototype;
+
+    // ---------------------------------------------------------------------
     // Patch Tray
-    // -------------------------------------------------------------------------
-    // The macOS app creates a Tray with a template image that doesn't exist on
-    // Linux, resulting in three dots and no click behavior.  Replace the icon
-    // and add a click handler that shows/focuses the main window.
+    // ---------------------------------------------------------------------
+    function patchTrayIcon(icon) {
+      if (!trayIcon) return icon;
+      try {
+        const orig = (typeof icon === 'string')
+          ? electron.nativeImage.createFromPath(icon)
+          : icon;
+        if (!orig || orig.isEmpty()) {
+          return trayIcon;
+        }
+      } catch (_) {
+        return trayIcon;
+      }
+      return icon;
+    }
+
+    function addTrayClickHandler(tray) {
+      tray.on('click', () => {
+        const wins = OrigBrowserWindow.getAllWindows();
+        const mainWin = wins.find(w => !w.isDestroyed()) || null;
+        if (mainWin) {
+          if (mainWin.isMinimized()) mainWin.restore();
+          mainWin.show();
+          mainWin.focus();
+        }
+      });
+    }
+
     const PatchedTray = new Proxy(OrigTray, {
       construct(Target, [icon, ...rest]) {
-        // Replace the icon if it's empty/broken or if we have a better one.
-        let resolvedIcon = icon;
-        if (trayIcon) {
-          try {
-            // Check if the original icon is a valid, non-empty nativeImage.
-            const orig = (typeof icon === 'string')
-              ? electron.nativeImage.createFromPath(icon)
-              : icon;
-            if (!orig || orig.isEmpty()) {
-              resolvedIcon = trayIcon;
-            }
-          } catch (_) {
-            resolvedIcon = trayIcon;
-          }
-        }
-
+        const resolvedIcon = patchTrayIcon(icon);
+        log('Tray construct intercepted: icon=' + (resolvedIcon === trayIcon ? 'replaced' : 'original'));
         const tray = Reflect.construct(Target, [resolvedIcon, ...rest], Target);
-
-        // Wire up click to show/focus the main window (macOS handles this
-        // natively but Linux tray click does nothing by default).
-        tray.on('click', () => {
-          const wins = electron.BrowserWindow.getAllWindows();
-          const mainWin = wins.find(w => !w.isDestroyed()) || null;
-          if (mainWin) {
-            if (mainWin.isMinimized()) mainWin.restore();
-            mainWin.show();
-            mainWin.focus();
-          }
-        });
-
-        if (debug) process.stderr.write('[native-frame] Tray patched: icon replaced, click handler added\n');
+        addTrayClickHandler(tray);
+        log('Tray click handler added');
         return tray;
       },
     });
 
-    // -------------------------------------------------------------------------
+    Object.setPrototypeOf(PatchedTray, OrigTray);
+    PatchedTray.prototype = OrigTray.prototype;
+
+    // ---------------------------------------------------------------------
     // Apply patches to electron module
-    // -------------------------------------------------------------------------
-    // In newer Electron versions, properties on the electron module may be
-    // non-configurable, causing Object.defineProperty to throw.  Try direct
-    // property definition first; if that fails, override Module._load to
-    // intercept all require('electron') calls and return a Proxy with
-    // patched constructors.
+    // ---------------------------------------------------------------------
+    // Strategy 1: Direct property replacement via defineProperty.
     let bwPatched = false;
     let trayPatched = false;
 
@@ -172,6 +216,7 @@ if (!global[INIT_SYM] && process.type === 'browser') {
         value: PatchedBrowserWindow, writable: true, configurable: true, enumerable: true,
       });
       bwPatched = true;
+      log('BrowserWindow patched via defineProperty');
     } catch (_) { /* non-configurable — will use fallback */ }
 
     try {
@@ -179,15 +224,16 @@ if (!global[INIT_SYM] && process.type === 'browser') {
         value: PatchedTray, writable: true, configurable: true, enumerable: true,
       });
       trayPatched = true;
+      log('Tray patched via defineProperty');
     } catch (_) { /* non-configurable — will use fallback */ }
 
+    // Strategy 2: Module._load override to intercept all require('electron').
+    // This is used when defineProperty fails (non-configurable getters in newer
+    // Electron).  We wrap the CURRENT Module._load to stay compatible with
+    // other patches (e.g. shell-env-patch.js) that also override Module._load.
     if (!bwPatched || !trayPatched) {
-      // Fallback: override Module._load to intercept all require('electron')
-      // calls and return a Proxy with patched constructors.  This is more
-      // reliable than patching Module._cache because Electron's built-in
-      // modules may bypass the standard module cache entirely.
       const Module = require('module');
-      const origLoad = Module._load;
+      const prevLoad = Module._load;
       const electronProxy = new Proxy(electron, {
         get(target, prop, receiver) {
           if (!bwPatched && prop === 'BrowserWindow') return PatchedBrowserWindow;
@@ -195,29 +241,50 @@ if (!global[INIT_SYM] && process.type === 'browser') {
           return Reflect.get(target, prop, receiver);
         },
       });
-      Module._load = function(request, parent, isMain) {
+      Module._load = function patchedElectronLoad(request, parent, isMain) {
         if (request === 'electron') return electronProxy;
-        return origLoad.call(this, request, parent, isMain);
+        return prevLoad.call(this, request, parent, isMain);
       };
-      process.stderr.write('[native-frame] Used Module._load Proxy fallback for patching\n');
+      log('Module._load Proxy fallback installed (bw=' + bwPatched + ', tray=' + trayPatched + ')');
     }
 
-    // Safety net: if BrowserWindow was not patched via defineProperty, at least
-    // set the icon on windows as they are created.
-    if (!bwPatched && appIcon) {
-      const app = electron.app || electron.default?.app;
-      if (app) {
-        app.on('browser-window-created', (_event, win) => {
-          try { win.setIcon(appIcon); } catch (_) { /* best effort */ }
+    // Strategy 3: Safety net via app events.  Even if the Proxy/Module._load
+    // interception misses some BrowserWindow or Tray instances (e.g. if the
+    // app caches its own reference to the constructor before our patch runs),
+    // these listeners provide a second chance.
+    const app = electron.app || electron.default?.app;
+    if (app) {
+      // 3a. Patch BrowserWindow instances after creation (icon + show frame).
+      // Note: frame:true cannot be changed after construction, but the icon can.
+      app.on('browser-window-created', (_event, win) => {
+        try {
+          if (appIcon) {
+            win.setIcon(appIcon);
+          }
+          // Remove any vibrancy/transparency that the macOS code sets.
+          if (typeof win.setVibrancy === 'function') {
+            try { win.setVibrancy(null); } catch (_) {}
+          }
+        } catch (e) {
+          log(`browser-window-created handler error: ${e.message}`);
+        }
+      });
+
+      // 3b. Double-ensure Module._load intercepts 'electron' after app is
+      // ready.  Some Electron versions defer internal module initialization
+      // until after 'ready', so re-apply the Module._load override here if
+      // it wasn't done above (e.g. defineProperty succeeded but the module
+      // got re-required later from a fresh reference).
+      if (!bwPatched || !trayPatched) {
+        app.once('ready', () => {
+          log('App ready — Module._load intercept still active');
         });
       }
     }
 
-    if (debug) {
-      process.stderr.write(`[native-frame] BrowserWindow patched: frame=true, icon=${appIcon ? 'set' : 'none'}\n`);
-      process.stderr.write(`[native-frame] Tray patched: icon=${trayIcon ? 'set' : 'none'}\n`);
-    }
+    log('Patches installed: BrowserWindow(frame=true, icon=' + (appIcon ? 'set' : 'none') +
+        '), Tray(icon=' + (trayIcon ? 'set' : 'none') + ', click=handler)');
   } catch (e) {
-    process.stderr.write(`[native-frame] setup failed: ${e.message}\n`);
+    process.stderr.write(`[native-frame] setup failed: ${e.message}\n${e.stack}\n`);
   }
 }

--- a/patches/native-frame.js
+++ b/patches/native-frame.js
@@ -141,10 +141,10 @@ if (!global[INIT_SYM] && process.type === 'browser') {
     }
 
     const PatchedBrowserWindow = new Proxy(OrigBrowserWindow, {
-      construct(Target, [options = {}, ...rest]) {
+      construct(Target, [options = {}, ...rest], newTarget) {
         const patched = patchBrowserWindowOptions(options);
         log('BrowserWindow construct intercepted: icon=' + (patched.icon ? 'set' : 'none'));
-        return Reflect.construct(Target, [patched, ...rest], Target);
+        return Reflect.construct(Target, [patched, ...rest], newTarget);
       },
     });
 
@@ -184,10 +184,10 @@ if (!global[INIT_SYM] && process.type === 'browser') {
     }
 
     const PatchedTray = new Proxy(OrigTray, {
-      construct(Target, [icon, ...rest]) {
+      construct(Target, [icon, ...rest], newTarget) {
         const resolvedIcon = patchTrayIcon(icon);
         log('Tray construct intercepted: icon=' + (resolvedIcon === trayIcon ? 'replaced' : 'original'));
-        const tray = Reflect.construct(Target, [resolvedIcon, ...rest], Target);
+        const tray = Reflect.construct(Target, [resolvedIcon, ...rest], newTarget);
         addTrayClickHandler(tray);
         log('Tray click handler added');
         return tray;
@@ -247,8 +247,7 @@ if (!global[INIT_SYM] && process.type === 'browser') {
     // these listeners provide a second chance.
     const app = electron.app || electron.default?.app;
     if (app) {
-      // 3a. Patch BrowserWindow instances after creation (icon + show frame).
-      // Note: frame:true cannot be changed after construction, but the icon can.
+      // 3a. Patch BrowserWindow instances after creation (icon only).
       app.on('browser-window-created', (_event, win) => {
         try {
           if (appIcon) {
@@ -259,14 +258,10 @@ if (!global[INIT_SYM] && process.type === 'browser') {
         }
       });
 
-      // 3b. Double-ensure Module._load intercepts 'electron' after app is
-      // ready.  Some Electron versions defer internal module initialization
-      // until after 'ready', so re-apply the Module._load override here if
-      // it wasn't done above (e.g. defineProperty succeeded but the module
-      // got re-required later from a fresh reference).
+      // 3b. Log confirmation that Module._load intercept is active at ready time.
       if (!bwPatched || !trayPatched) {
         app.once('ready', () => {
-          log('App ready — Module._load intercept still active');
+          log('App ready — Module._load intercept active (bw=' + bwPatched + ', tray=' + trayPatched + ')');
         });
       }
     }

--- a/patches/shell-env-patch.js
+++ b/patches/shell-env-patch.js
@@ -1,0 +1,67 @@
+'use strict';
+/**
+ * shell-env-patch.js
+ *
+ * Fixes the "Shell path worker not found" error on Linux.
+ *
+ * Claude Desktop uses a Worker thread (shellPathWorker.js) to extract the
+ * user's shell environment by spawning their login shell.  The worker path is
+ * resolved relative to process.resourcesPath, which on Linux points to the
+ * system Electron's resources directory — not the app's actual ASAR location.
+ *
+ * On Linux the app already runs inside the user's shell environment, so
+ * process.env contains the correct PATH and other variables.  Rather than
+ * fixing the path, we intercept the worker_threads.Worker constructor and
+ * provide a tiny inline worker that returns process.env directly.
+ *
+ * Injected at the top of the main-process bundle by patch-cowork.sh.
+ */
+
+const INIT_SYM = Symbol.for('__claudeShellEnvPatchInitialised');
+
+if (!global[INIT_SYM] && process.type === 'browser') {
+  global[INIT_SYM] = true;
+  try {
+    const Module = require('module');
+    const origLoad = Module._load;
+
+    Module._load = function (request, parent, isMain) {
+      const mod = origLoad.call(this, request, parent, isMain);
+
+      // Intercept worker_threads to patch the Worker constructor.
+      if (request === 'worker_threads' || request === 'node:worker_threads') {
+        if (mod && mod.Worker && !mod.__shellEnvPatched) {
+          const OrigWorker = mod.Worker;
+
+          mod.Worker = function PatchedWorker(filename, options) {
+            // Detect the shell path worker by filename.
+            if (typeof filename === 'string' && filename.includes('shellPathWorker')) {
+              // Return an inline worker that immediately posts back process.env.
+              const workerCode = `
+                const { parentPort } = require('worker_threads');
+                parentPort.on('message', () => {
+                  parentPort.postMessage({ env: process.env });
+                });
+              `;
+              return new OrigWorker(workerCode, {
+                ...options,
+                eval: true,
+              });
+            }
+            return new OrigWorker(filename, options);
+          };
+
+          // Preserve prototype chain for instanceof checks.
+          mod.Worker.prototype = OrigWorker.prototype;
+          mod.__shellEnvPatched = true;
+        }
+      }
+
+      return mod;
+    };
+
+    process.stderr.write('[shell-env-patch] Shell environment worker patch installed.\n');
+  } catch (e) {
+    process.stderr.write(`[shell-env-patch] Warning: ${e.message}\n`);
+  }
+}

--- a/patches/shell-env-patch.js
+++ b/patches/shell-env-patch.js
@@ -36,17 +36,33 @@ if (!global[INIT_SYM] && process.type === 'browser') {
           mod.Worker = function PatchedWorker(filename, options) {
             // Detect the shell path worker by filename.
             if (typeof filename === 'string' && filename.includes('shellPathWorker')) {
-              // Return an inline worker that immediately posts back process.env.
-              const workerCode = `
-                const { parentPort } = require('worker_threads');
-                parentPort.on('message', () => {
-                  parentPort.postMessage({ env: process.env });
-                });
-              `;
-              return new OrigWorker(workerCode, {
-                ...options,
-                eval: true,
-              });
+              // First, try to construct the original worker as-is. If that fails
+              // due to a missing/unloadable script, fall back to an inline worker
+              // that immediately posts back process.env.
+              try {
+                return new OrigWorker(filename, options);
+              } catch (err) {
+                const code = err && err.code;
+                if (
+                  code === 'ENOENT' ||
+                  code === 'MODULE_NOT_FOUND' ||
+                  code === 'ERR_MODULE_NOT_FOUND' ||
+                  code === 'ERR_WORKER_NOT_FOUND'
+                ) {
+                  process.stderr.write(`[shell-env-patch] Original worker failed (${code}), using inline fallback.\n`);
+                  const workerCode = `
+                    const { parentPort } = require('worker_threads');
+                    parentPort.on('message', () => {
+                      parentPort.postMessage({ env: process.env });
+                    });
+                  `;
+                  return new OrigWorker(workerCode, {
+                    ...options,
+                    eval: true,
+                  });
+                }
+                throw err;
+              }
             }
             return new OrigWorker(filename, options);
           };

--- a/scripts/patch-cowork.sh
+++ b/scripts/patch-cowork.sh
@@ -332,6 +332,12 @@ if [[ -z "$ICON_COPIED" ]]; then
   fi
 fi
 
+# -- shell-env-patch (already CJS, just copy) ---------------------------------
+SHELL_ENV_SRC="$PATCHES_DIR/shell-env-patch.js"
+SHELL_ENV_DEST="$MAIN_ENTRY_DIR/shell-env-patch.js"
+cp "$SHELL_ENV_SRC" "$SHELL_ENV_DEST"
+log "Copied shell-env-patch to $SHELL_ENV_DEST"
+
 # -- platform-override (already CJS, just copy) -------------------------------
 PLAT_OVERRIDE_SRC="$PATCHES_DIR/platform-override.js"
 PLAT_OVERRIDE_DEST="$MAIN_ENTRY_DIR/platform-override.js"
@@ -339,11 +345,12 @@ cp "$PLAT_OVERRIDE_SRC" "$PLAT_OVERRIDE_DEST"
 log "Copied platform-override to $PLAT_OVERRIDE_DEST"
 
 # -- Prepend all requires (idempotent: skip if already present) ---------------
-if head -1 "$MAIN_ENTRY" | grep -qF 'open-url-bridge'; then
+if head -1 "$MAIN_ENTRY" | grep -qF 'shell-env-patch'; then
   log "Patches already injected into $MAIN_ENTRY — skipping prepend."
 else
   TMPFILE="$(mktemp)"
   {
+    echo "require('./shell-env-patch.js');"
     echo "require('./platform-override.js');"
     echo "require('./native-frame.js');"
     echo "require('./open-url-bridge.js');"
@@ -351,7 +358,7 @@ else
     cat "$MAIN_ENTRY"
   } > "$TMPFILE"
   mv "$TMPFILE" "$MAIN_ENTRY"
-  log "Prepended platform-override + native-frame + open-url-bridge + path-translator to $MAIN_ENTRY"
+  log "Prepended shell-env-patch + platform-override + native-frame + open-url-bridge + path-translator to $MAIN_ENTRY"
 fi
 
 # ---------------------------------------------------------------------------
@@ -372,6 +379,7 @@ log "  Gate-patched file   : $GATE_FILE"
 log "  Gate location       : start=$GATE_START  end=$GATE_END"
 log "  CCD platform patch  : linux-x64/linux-arm64 added to getHostPlatform + getBinaryPathIfReady"
 log "  Patches injected    : $MAIN_ENTRY"
+log "    shell-env-patch.js (fix shell path worker not found on Linux)"
 log "    platform-override.js (runtime fallback for platform gate)"
 log "    native-frame.js    (force frame:true on all BrowserWindow instances)"
 log "    open-url-bridge.js (second-instance → open-url bridge for Linux OAuth)"

--- a/scripts/patch-cowork.sh
+++ b/scripts/patch-cowork.sh
@@ -345,7 +345,7 @@ cp "$PLAT_OVERRIDE_SRC" "$PLAT_OVERRIDE_DEST"
 log "Copied platform-override to $PLAT_OVERRIDE_DEST"
 
 # -- Prepend all requires (idempotent: skip if already present) ---------------
-if head -1 "$MAIN_ENTRY" | grep -qF 'shell-env-patch'; then
+if grep -qF 'shell-env-patch' "$MAIN_ENTRY"; then
   log "Patches already injected into $MAIN_ENTRY — skipping prepend."
 else
   TMPFILE="$(mktemp)"
@@ -381,7 +381,7 @@ log "  CCD platform patch  : linux-x64/linux-arm64 added to getHostPlatform + ge
 log "  Patches injected    : $MAIN_ENTRY"
 log "    shell-env-patch.js (fix shell path worker not found on Linux)"
 log "    platform-override.js (runtime fallback for platform gate)"
-log "    native-frame.js    (force frame:true on all BrowserWindow instances)"
+log "    native-frame.js    (icon injection + tray click handler for Linux)"
 log "    open-url-bridge.js (second-instance → open-url bridge for Linux OAuth)"
 log "    path-translator.js (/sessions/… path remapping)"
 log "------------------------------------------------------------"


### PR DESCRIPTION
## Summary
This PR enhances the Linux compatibility patches for Claude Desktop by adding a programmatic fallback icon and fixing the shell environment worker path resolution issue.

## Key Changes

### native-frame.js
- **Removed forced frame:true behavior**: The patch no longer forces native OS window decorations, allowing the app to use its preferred window styling
- **Added programmatic fallback icon**: Implements `createFallbackIcon()` that generates a minimal 32x32 PNG-encoded orange circle icon as a last resort when system and bundled icons are unavailable. This ensures the app always has some icon for display in titlebars and taskbars
- **Enhanced icon resolution chain**: Now tries system icons → bundled ASAR icons → programmatic fallback (previously stopped at bundled icons)
- **Added SVG support**: Includes `/usr/share/icons/hicolor/scalable/apps/claude-desktop.svg` in system icon search paths
- **Improved error handling and logging**: Replaced simple debug flag with structured `log()` function that provides detailed error messages for icon loading failures and patch application steps
- **Refactored patching strategy**: Extracted icon patching logic into reusable `patchBrowserWindowOptions()` and `patchTrayIcon()` functions for better maintainability
- **Added safety net event handlers**: Implements `browser-window-created` listener as a fallback mechanism to ensure icons are set even if the Proxy/Module._load interception misses some instances
- **Better error recovery**: Tray icon resize failures now fall back to full-size icon instead of failing silently

### shell-env-patch.js (new file)
- **Fixes "Shell path worker not found" error on Linux**: The app's shell environment worker (shellPathWorker.js) path is resolved relative to system Electron's resources directory on Linux, not the app's ASAR location
- **Inline worker replacement**: Intercepts `worker_threads.Worker` constructor and replaces shell path worker instantiation with an inline worker that directly returns `process.env`
- **Leverages existing shell environment**: Since the app already runs in the user's shell context on Linux, `process.env` contains the correct PATH and variables without needing to spawn a login shell

### patch-cowork.sh
- **Integrated shell-env-patch**: Added copying and prepending of the new shell-env-patch.js module to the main entry point
- **Updated injection order**: shell-env-patch now runs first, followed by platform-override, native-frame, open-url-bridge, and path-translator

## Notable Implementation Details
- The fallback icon is a base64-encoded PNG embedded directly in the code to avoid external file dependencies
- The Module._load override wraps the previous override to maintain compatibility with other patches
- Icon resolution logs detailed information about which paths were tried and why they failed, aiding in debugging
- The shell environment worker patch uses `eval: true` to execute inline code instead of loading from a file path

https://claude.ai/code/session_016axFrvPfv2jUeyR79LeTb3