### PR TITLE
fix: serve pacman package from GitHub Releases instead of Pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,6 +148,14 @@ jobs:
             sha256sum "$dst" | awk '{print $1}' > "${dst}.sha256"
             rm -f "${src}.sha256"
           done
+          # Create a pacman-compatible named copy (no "repack" — pacman requires
+          # {name}-{pkgver}-{pkgrel}-{arch}.pkg.tar.ext filename format).
+          REPACK_PKG="output/claude-desktop-${VERSION}-repack-${REPACK}-x86_64.pkg.tar.zst"
+          PACMAN_PKG="output/claude-desktop-${VERSION}-${REPACK}-x86_64.pkg.tar.zst"
+          if [[ -f "$REPACK_PKG" ]]; then
+            cp "$REPACK_PKG" "$PACMAN_PKG"
+            cp "${REPACK_PKG}.sha256" "${PACMAN_PKG}.sha256"
+          fi
           # Rename the Nix tarball (different naming convention).
           NIX_SRC="output/claude-desktop-${VERSION}-x86_64-nix.tar.gz"
           NIX_DST="output/claude-desktop-${VERSION}-repack-${REPACK}-x86_64-nix.tar.gz"
@@ -227,9 +235,11 @@ jobs:
 
           # Build asset list — only include files that actually exist.
           ASSETS=()
+          PACMAN_BASE="output/claude-desktop-${VERSION}-${REPACK}-x86_64"
           for f in "${BASE}.rpm" "${BASE}.rpm.sha256" \
                    "${BASE}.deb" "${BASE}.deb.sha256" \
                    "${BASE}.pkg.tar.zst" "${BASE}.pkg.tar.zst.sha256" \
+                   "${PACMAN_BASE}.pkg.tar.zst" "${PACMAN_BASE}.pkg.tar.zst.sha256" \
                    "${BASE}-nix.tar.gz" "${BASE}-nix.tar.gz.sha256" \
                    "${BASE}.AppImage" "${BASE}.AppImage.sha256" \
                    "${BASE}.AppImage.zsync"; do


### PR DESCRIPTION
GitHub Pages CDN can corrupt large binary files, causing pacman's integrity check to fail. Instead:

- Upload a pacman-compatible named copy (without "repack") as a GitHub Release asset alongside the existing one
- Keep only the repo DB on Pages
- Add a second Server line pointing to Releases latest download so pacman fetches the DB from Pages and the package from Releases

https://claude.ai/code/session_016zTCq9fKoqEfRG8RVvJn4G