### PR TITLE
Support multiple platform-gate functions in single bundle

### DIFF
--- a/patches/apply-platform-gate.mjs
+++ b/patches/apply-platform-gate.mjs
@@ -134,7 +134,7 @@ for (const [bundlePath, locs] of byFile) {
     // Sanity: range must look like a function body
     const originalBody = src.slice(start, end);
     const trimmedBody  = originalBody.trim();
-    if (trimmedBody[0] !== '{' || trimmedBody[trimmedBody.length - 1] !== '}') {
+    if (!trimmedBody || trimmedBody[0] !== '{' || trimmedBody[trimmedBody.length - 1] !== '}') {
       process.stderr.write(
         `[apply-platform-gate] Range [${start}..${end}] does not look like a function body ` +
         `(expected '{' … '}') — skipping.\n` +
@@ -154,7 +154,12 @@ for (const [bundlePath, locs] of byFile) {
     totalPatched++;
   }
 
-  writeFileSync(bundlePath, src, 'utf8');
+  try {
+    writeFileSync(bundlePath, src, 'utf8');
+  } catch (err) {
+    process.stderr.write(`[apply-platform-gate] Cannot write ${bundlePath}: ${err.message}\n`);
+    process.exit(1);
+  }
 }
 
 if (totalPatched === 0) {

--- a/patches/apply-platform-gate.mjs
+++ b/patches/apply-platform-gate.mjs
@@ -2,8 +2,8 @@
 /**
  * apply-platform-gate.mjs
  *
- * Splice the platform-gate function body in a minified JS bundle,
- * replacing it with an unconditional `return { status: "supported" }`.
+ * Splice the platform-gate function body (or bodies) in a minified JS bundle,
+ * replacing each with an unconditional `return { status: "supported" }`.
  *
  * Usage:
  *   node patches/apply-platform-gate.mjs [--input <gate-location.json>]
@@ -11,11 +11,14 @@
  *   --input   Path to gate-location.json written by find-platform-gate.mjs.
  *             Default: $BUILD_DIR/gate-location.json, or ./gate-location.json.
  *
- * The JSON must contain { file, start, end }.
- * The bundle at `file` is patched in-place.
+ * The JSON must contain EITHER:
+ *   { file, start, end }                          — single gate (legacy format)
+ *   { gates: [{ file, start, end }, ...] }        — multi-gate format (--all mode)
+ *
+ * All bundles are patched in-place.
  *
  * Exit 0 on success. Exit 1 if the file doesn't exist, JSON is malformed,
- * or the character range is out of bounds.
+ * or any character range is out of bounds.
  */
 
 import { readFileSync, writeFileSync, existsSync } from 'fs';
@@ -61,74 +64,102 @@ try {
   process.exit(1);
 }
 
-const { file: bundlePath, start, end } = gateInfo;
-
-if (typeof bundlePath !== 'string' || typeof start !== 'number' || typeof end !== 'number') {
+// ---------------------------------------------------------------------------
+// Normalise: accept either single-gate { file, start, end } or
+// multi-gate { gates: [...] } format (written by find-platform-gate --all).
+// ---------------------------------------------------------------------------
+let gates;
+if (Array.isArray(gateInfo.gates)) {
+  gates = gateInfo.gates;
+  process.stderr.write(`[apply-platform-gate] Multi-gate mode: ${gates.length} gate(s) to patch.\n`);
+} else if (typeof gateInfo.file === 'string' && typeof gateInfo.start === 'number' && typeof gateInfo.end === 'number') {
+  gates = [{ file: gateInfo.file, start: gateInfo.start, end: gateInfo.end }];
+} else {
   process.stderr.write(
-    '[apply-platform-gate] JSON must contain { file: string, start: number, end: number }\n'
+    '[apply-platform-gate] JSON must contain { file, start, end } or { gates: [...] }\n'
   );
   process.exit(1);
 }
 
 // ---------------------------------------------------------------------------
-// Load bundle
-// ---------------------------------------------------------------------------
-let src;
-try {
-  if (!existsSync(bundlePath)) {
-    process.stderr.write(`[apply-platform-gate] Bundle not found: ${bundlePath}\n`);
-    process.exit(1);
-  }
-  src = readFileSync(bundlePath, 'utf8');
-} catch (err) {
-  process.stderr.write(`[apply-platform-gate] Cannot read ${bundlePath}: ${err.message}\n`);
-  process.exit(1);
-}
-
-// ---------------------------------------------------------------------------
-// Bounds check
-// ---------------------------------------------------------------------------
-if (start < 0 || end > src.length || start >= end) {
-  process.stderr.write(
-    `[apply-platform-gate] Character range [${start}..${end}] is out of bounds ` +
-    `for file of length ${src.length}.\n`
-  );
-  process.exit(1);
-}
-
-// ---------------------------------------------------------------------------
-// Sanity: verify the range looks like a function body
-// ---------------------------------------------------------------------------
-const originalBody = src.slice(start, end);
-
-if (originalBody[0] !== '{' || originalBody[originalBody.length - 1] !== '}') {
-  process.stderr.write(
-    `[apply-platform-gate] Range [${start}..${end}] does not look like a function body ` +
-    `(expected to start with '{' and end with '}').\n` +
-    `  Starts with: ${JSON.stringify(originalBody.slice(0, 20))}\n` +
-    `  Ends with:   ${JSON.stringify(originalBody.slice(-20))}\n`
-  );
-  process.exit(1);
-}
-
-// ---------------------------------------------------------------------------
-// Patch — string splice, no regex, no re-parsing
+// Patch each gate — string splice, no regex, no re-parsing
+//
+// When multiple gates live in the SAME file we must apply them from last to
+// first (descending start offset) so that patching one gate doesn't shift
+// the character offsets of subsequent gates.
 // ---------------------------------------------------------------------------
 const REPLACEMENT = '{return{status:"supported"}}';
 
-const patched =
-  src.slice(0, start) +
-  REPLACEMENT +
-  src.slice(end);
+// Group by file
+/** @type {Map<string, Array<{ start: number, end: number }>>} */
+const byFile = new Map();
+for (const gate of gates) {
+  if (typeof gate.file !== 'string' || typeof gate.start !== 'number' || typeof gate.end !== 'number') {
+    process.stderr.write(`[apply-platform-gate] Skipping malformed gate entry: ${JSON.stringify(gate)}\n`);
+    continue;
+  }
+  if (!byFile.has(gate.file)) byFile.set(gate.file, []);
+  byFile.get(gate.file).push({ start: gate.start, end: gate.end });
+}
 
-writeFileSync(bundlePath, patched, 'utf8');
+let totalPatched = 0;
 
-// ---------------------------------------------------------------------------
-// Log
-// ---------------------------------------------------------------------------
-process.stderr.write(
-  `[apply-platform-gate] Patched ${bundlePath}\n` +
-  `  Original body length : ${originalBody.length}\n` +
-  `  Patched body length  : ${REPLACEMENT.length}\n` +
-  `  Original body preview: ${originalBody.slice(0, 80)}\n`
-);
+for (const [bundlePath, locs] of byFile) {
+  // Load bundle
+  let src;
+  try {
+    if (!existsSync(bundlePath)) {
+      process.stderr.write(`[apply-platform-gate] Bundle not found: ${bundlePath}\n`);
+      process.exit(1);
+    }
+    src = readFileSync(bundlePath, 'utf8');
+  } catch (err) {
+    process.stderr.write(`[apply-platform-gate] Cannot read ${bundlePath}: ${err.message}\n`);
+    process.exit(1);
+  }
+
+  // Sort descending so later offsets are patched first (preserves earlier offsets).
+  locs.sort((a, b) => b.start - a.start);
+
+  for (const { start, end } of locs) {
+    // Bounds check
+    if (start < 0 || end > src.length || start >= end) {
+      process.stderr.write(
+        `[apply-platform-gate] Character range [${start}..${end}] is out of bounds ` +
+        `for file of length ${src.length} — skipping.\n`
+      );
+      continue;
+    }
+
+    // Sanity: range must look like a function body
+    const originalBody = src.slice(start, end);
+    const trimmedBody  = originalBody.trim();
+    if (trimmedBody[0] !== '{' || trimmedBody[trimmedBody.length - 1] !== '}') {
+      process.stderr.write(
+        `[apply-platform-gate] Range [${start}..${end}] does not look like a function body ` +
+        `(expected '{' … '}') — skipping.\n` +
+        `  Starts with: ${JSON.stringify(originalBody.slice(0, 20))}\n` +
+        `  Ends with:   ${JSON.stringify(originalBody.slice(-20))}\n`
+      );
+      continue;
+    }
+
+    src = src.slice(0, start) + REPLACEMENT + src.slice(end);
+
+    process.stderr.write(
+      `[apply-platform-gate] Patched [${start}..${end}] in ${bundlePath}\n` +
+      `  Original length : ${originalBody.length}  →  Replacement length: ${REPLACEMENT.length}\n` +
+      `  Preview: ${originalBody.slice(0, 80)}\n`
+    );
+    totalPatched++;
+  }
+
+  writeFileSync(bundlePath, src, 'utf8');
+}
+
+if (totalPatched === 0) {
+  process.stderr.write('[apply-platform-gate] ERROR: No gates were patched (all entries were skipped).\n');
+  process.exit(1);
+}
+
+process.stderr.write(`[apply-platform-gate] Done — ${totalPatched} gate(s) patched.\n`);

--- a/patches/find-platform-gate.mjs
+++ b/patches/find-platform-gate.mjs
@@ -34,6 +34,8 @@ import { simple }                                   from 'acorn-walk';
 // ---------------------------------------------------------------------------
 const rawArgs = process.argv.slice(2);
 const dumpAll = rawArgs.includes('--dump-candidates');
+// --all: output every match above threshold, not just the single best
+const outputAll = rawArgs.includes('--all');
 
 // --output <path>
 let outputPath = null;
@@ -358,13 +360,21 @@ if (topMatches.length === 0) {
   process.exit(1);
 }
 
-// --- ambiguous: pick the highest score, then shortest body (most likely the concise gate) ---
+// Sort: best score first, then shortest body within same score (most concise = most likely the gate)
+topMatches.sort((a, b) => b.score - a.score || (a.end - a.start) - (b.end - b.start));
+
 if (topMatches.length > 1) {
-  topMatches.sort((a, b) => b.score - a.score || (a.end - a.start) - (b.end - b.start));
-  process.stderr.write(
-    `[find-platform-gate] ${topMatches.length} matches above threshold (${THRESHOLD}/${MAX_SCORE}); ` +
-    `selecting best (score=${topMatches[0].score}, ${topMatches[0].end - topMatches[0].start} chars).\n`
-  );
+  if (outputAll) {
+    process.stderr.write(
+      `[find-platform-gate] ${topMatches.length} matches above threshold (${THRESHOLD}/${MAX_SCORE}); ` +
+      `outputting all (--all mode).\n`
+    );
+  } else {
+    process.stderr.write(
+      `[find-platform-gate] ${topMatches.length} matches above threshold (${THRESHOLD}/${MAX_SCORE}); ` +
+      `selecting best (score=${topMatches[0].score}, ${topMatches[0].end - topMatches[0].start} chars).\n`
+    );
+  }
   for (const c of topMatches.slice(0, 5)) {
     process.stderr.write(
       `  score=${c.score}/${MAX_SCORE}  ${c.end - c.start} chars  ${c.file}:[${c.start}..${c.end}]  ${c.preview}\n`
@@ -372,15 +382,34 @@ if (topMatches.length > 1) {
   }
 }
 
-// --- exactly one ---
-const best = topMatches[0];
-const result = {
-  file:    best.file,
-  start:   best.start,
-  end:     best.end,
-  score:   best.score,
-  preview: best.preview,
-};
+// --- Build output ---
+let result;
+if (outputAll) {
+  // --all mode: output every match above threshold so apply-platform-gate can patch all of them.
+  // This is important when Cowork and Dispatch have separate gate functions in the same bundle.
+  result = {
+    gates: topMatches.map(c => ({
+      file:    c.file,
+      start:   c.start,
+      end:     c.end,
+      score:   c.score,
+      preview: c.preview,
+    })),
+  };
+  process.stderr.write(
+    `[find-platform-gate] Emitting ${result.gates.length} gate(s) in multi-gate mode.\n`
+  );
+} else {
+  // Default: single best match (legacy format)
+  const best = topMatches[0];
+  result = {
+    file:    best.file,
+    start:   best.start,
+    end:     best.end,
+    score:   best.score,
+    preview: best.preview,
+  };
+}
 
 const json = JSON.stringify(result, null, 2) + '\n';
 process.stdout.write(json);

--- a/patches/native-frame.js
+++ b/patches/native-frame.js
@@ -157,22 +157,16 @@ if (!global[INIT_SYM] && process.type === 'browser') {
     // Patch Tray
     // ---------------------------------------------------------------------
     function patchTrayIcon(icon) {
-      if (!trayIcon) return icon;
-      try {
-        const orig = (typeof icon === 'string')
-          ? electron.nativeImage.createFromPath(icon)
-          : icon;
-        if (!orig || orig.isEmpty()) {
-          return trayIcon;
-        }
-      } catch (_) {
-        return trayIcon;
-      }
-      return icon;
+      // Always use our pre-resolved, Linux-compatible tray icon when available.
+      // The macOS icon passed by the app (often a .icns resource path or an
+      // Electron-packaged ASAR resource) may load as non-empty on Linux but
+      // still renders as "three dots" in the system tray because it is a
+      // macOS-specific format not understood by Linux tray hosts.
+      return trayIcon || icon;
     }
 
     function addTrayClickHandler(tray) {
-      tray.on('click', () => {
+      const showWindow = () => {
         const wins = OrigBrowserWindow.getAllWindows();
         const mainWin = wins.find(w => !w.isDestroyed()) || null;
         if (mainWin) {
@@ -180,7 +174,11 @@ if (!global[INIT_SYM] && process.type === 'browser') {
           mainWin.show();
           mainWin.focus();
         }
-      });
+      };
+      // 'click' covers most Linux tray implementations; 'double-click' is
+      // needed on some desktop environments (e.g. KDE Plasma with SNI).
+      tray.on('click', showWindow);
+      tray.on('double-click', showWindow);
     }
 
     const PatchedTray = new Proxy(OrigTray, {
@@ -188,6 +186,13 @@ if (!global[INIT_SYM] && process.type === 'browser') {
         const resolvedIcon = patchTrayIcon(icon);
         log('Tray construct intercepted: icon=' + (resolvedIcon === trayIcon ? 'replaced' : 'original'));
         const tray = Reflect.construct(Target, [resolvedIcon, ...rest], newTarget);
+        // Intercept setImage() so that post-construction icon updates (e.g.
+        // notification badges) also use our Linux-compatible icon instead of
+        // reverting to the macOS resource.
+        const origSetImage = tray.setImage.bind(tray);
+        tray.setImage = function patchedSetImage(img) {
+          return origSetImage(patchTrayIcon(img));
+        };
         addTrayClickHandler(tray);
         log('Tray click handler added');
         return tray;

--- a/patches/platform-override.js
+++ b/patches/platform-override.js
@@ -25,11 +25,18 @@ try {
   // -------------------------------------------------------------------------
   // Helpers
   // -------------------------------------------------------------------------
-  const NEGATIVE_STATUSES = new Set(['unsupported', 'unavailable', 'disabled']);
+  const NEGATIVE_STATUSES = new Set([
+    // Core platform gate negatives
+    'unsupported', 'unavailable', 'disabled',
+    // Update/download gate negatives — shown when CCD binary is missing/outdated
+    // or when the app thinks a newer Claude Desktop is required.
+    'update_required', 'download_required', 'out_of_date', 'outdated',
+    'requires_update', 'update_available', 'needs_update', 'not_ready',
+  ]);
 
   /**
-   * Recursively rewrite any { status: "unsupported"|"unavailable"|"disabled" }
-   * to { status: "supported" } in an object tree.  Returns true if any
+   * Recursively rewrite any { status: <negative> } to { status: "supported" }
+   * and flip boolean "blocked" flags in an object tree.  Returns true if any
    * rewrite was performed.
    */
   function rewriteStatus(obj, channel, depth) {
@@ -52,6 +59,28 @@ try {
         `[platform-override] Rewriting IPC "${channel}" supported: false → true\n`
       );
       obj.supported = true;
+      changed = true;
+    }
+
+    // Update/download flags: flip to "no update needed"
+    if (obj.needsUpdate === true) {
+      process.stderr.write(`[platform-override] Rewriting IPC "${channel}" needsUpdate: true → false\n`);
+      obj.needsUpdate = false;
+      changed = true;
+    }
+    if (obj.updateRequired === true) {
+      process.stderr.write(`[platform-override] Rewriting IPC "${channel}" updateRequired: true → false\n`);
+      obj.updateRequired = false;
+      changed = true;
+    }
+    if (obj.downloadRequired === true) {
+      process.stderr.write(`[platform-override] Rewriting IPC "${channel}" downloadRequired: true → false\n`);
+      obj.downloadRequired = false;
+      changed = true;
+    }
+    if (obj.isUpdateAvailable === true) {
+      process.stderr.write(`[platform-override] Rewriting IPC "${channel}" isUpdateAvailable: true → false\n`);
+      obj.isUpdateAvailable = false;
       changed = true;
     }
 
@@ -188,28 +217,49 @@ try {
             // Some renderer-side code checks feature objects like
             // { dispatch: { supported: false } } or { cowork: { status: "unsupported" } }.
             // We intercept window.postMessage and MessagePort to catch these.
+            // NOTE: This set must be kept in sync with NEGATIVE_STATUSES in the
+            // main-process section above.  It is duplicated here because the renderer
+            // runs in a separate V8 context and cannot share Node.js variables.
             try {
+              var NEGATIVE = new Set([
+                'unsupported','unavailable','disabled',
+                'update_required','download_required','out_of_date','outdated',
+                'requires_update','update_available','needs_update','not_ready',
+              ]);
+              function rewriteObj(o, depth) {
+                if (!o || typeof o !== 'object' || depth > 4) return;
+                if (typeof o.status === 'string' && NEGATIVE.has(o.status.toLowerCase())) {
+                  o.status = 'supported';
+                }
+                if (o.supported === false) o.supported = true;
+                if (o.needsUpdate === true)       o.needsUpdate = false;
+                if (o.updateRequired === true)    o.updateRequired = false;
+                if (o.downloadRequired === true)  o.downloadRequired = false;
+                if (o.isUpdateAvailable === true) o.isUpdateAvailable = false;
+                var keys = Object.keys(o);
+                for (var i = 0; i < keys.length; i++) {
+                  var v = o[keys[i]];
+                  if (v && typeof v === 'object' && !Array.isArray(v)) rewriteObj(v, depth + 1);
+                }
+              }
               var origPostMessage = window.postMessage;
               window.postMessage = function(msg) {
-                if (msg && typeof msg === 'object') {
-                  (function rewrite(o, depth) {
-                    if (!o || typeof o !== 'object' || depth > 4) return;
-                    if (typeof o.status === 'string') {
-                      var s = o.status.toLowerCase();
-                      if (s === 'unsupported' || s === 'unavailable' || s === 'disabled') {
-                        o.status = 'supported';
-                      }
-                    }
-                    if (o.supported === false) o.supported = true;
-                    var keys = Object.keys(o);
-                    for (var i = 0; i < keys.length; i++) {
-                      var v = o[keys[i]];
-                      if (v && typeof v === 'object' && !Array.isArray(v)) rewrite(v, depth + 1);
-                    }
-                  })(msg, 0);
-                }
+                if (msg && typeof msg === 'object') rewriteObj(msg, 0);
                 return origPostMessage.apply(this, arguments);
               };
+            } catch(e) {}
+
+            // --- Dispatch input event passthrough ---
+            // Dispatch's message input may be gated behind a feature-availability
+            // check that runs synchronously on the React render cycle.  We listen
+            // for the 'dispatch-feature-check' custom event and immediately respond
+            // with a 'dispatch-feature-ready' event so the input is never blocked.
+            try {
+              window.addEventListener('dispatch-feature-check', function() {
+                window.dispatchEvent(new CustomEvent('dispatch-feature-ready', {
+                  detail: { status: 'supported', supported: true }
+                }));
+              }, { passive: true });
             } catch(e) {}
           })();
         `).catch(() => {});

--- a/scripts/patch-cowork.sh
+++ b/scripts/patch-cowork.sh
@@ -154,7 +154,7 @@ GATE_SUMMARY="$(node -e \
 # ---------------------------------------------------------------------------
 # Patch 1 — Apply platform gate
 # ---------------------------------------------------------------------------
-log "Applying platform-gate patch to $GATE_FILE..."
+log "Applying platform-gate patch ($GATE_SUMMARY)..."
 
 APPLY_LOG="$BUILD_DIR/patch-apply.log"
 

--- a/scripts/patch-cowork.sh
+++ b/scripts/patch-cowork.sh
@@ -117,9 +117,10 @@ FIND_LOG="$BUILD_DIR/patch-find.log"
 FIND_EXIT=1
 
 for SCAN_DIR in "$VITE_BUILD_DIR" "$APP_DIR"; do
-  log "Searching for platform-gate function in $SCAN_DIR..."
+  log "Searching for platform-gate function(s) in $SCAN_DIR..."
   set +e
   node "$PATCHES_DIR/find-platform-gate.mjs" "$SCAN_DIR" \
+    --all \
     --output "$GATE_JSON" \
     2>"$FIND_LOG"
   FIND_EXIT=$?
@@ -141,18 +142,14 @@ if [[ $FIND_EXIT -ne 0 ]]; then
   exit 1
 fi
 
-log "Gate location: $(cat "$GATE_JSON")"
+log "Gate location(s): $(cat "$GATE_JSON")"
 
-# Extract fields for the summary (pass the path via argv to avoid quoting issues).
-GATE_FILE="$(node -e \
-  "const j=JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));process.stdout.write(j.file);" \
-  -- "$GATE_JSON")"
-GATE_START="$(node -e \
-  "const j=JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));process.stdout.write(String(j.start));" \
-  -- "$GATE_JSON")"
-GATE_END="$(node -e \
-  "const j=JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));process.stdout.write(String(j.end));" \
-  -- "$GATE_JSON")"
+# Extract a summary of found gates (file + count) for the log message.
+GATE_SUMMARY="$(node -e \
+  "const j=JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));
+   if(j.gates){process.stdout.write(j.gates.length+' gate(s) across '+[...new Set(j.gates.map(g=>g.file))].length+' file(s)');}
+   else{process.stdout.write('1 gate: '+j.file+' ['+j.start+'..'+j.end+']');}" \
+  -- "$GATE_JSON" 2>/dev/null || echo "unknown")"
 
 # ---------------------------------------------------------------------------
 # Patch 1 — Apply platform gate
@@ -375,8 +372,7 @@ touch "$GUARD"
 # ---------------------------------------------------------------------------
 log "------------------------------------------------------------"
 log "Patch summary"
-log "  Gate-patched file   : $GATE_FILE"
-log "  Gate location       : start=$GATE_START  end=$GATE_END"
+log "  Platform-gate patch : $GATE_SUMMARY (all gates patched to return {status:\"supported\"})"
 log "  CCD platform patch  : linux-x64/linux-arm64 added to getHostPlatform + getBinaryPathIfReady"
 log "  Patches injected    : $MAIN_ENTRY"
 log "    shell-env-patch.js (fix shell path worker not found on Linux)"

--- a/stubs/claude-native.js
+++ b/stubs/claude-native.js
@@ -72,6 +72,54 @@ function getFeatureAvailability(feature) {
 }
 
 // ---------------------------------------------------------------------------
+// Push notification stubs — required for Dispatch message delivery.
+//
+// On macOS, Dispatch registers with APNs to receive a device token that is
+// used for mobile-to-desktop message routing.  On Linux there is no APNs;
+// we return a plausible-looking token so the registration path succeeds and
+// the app's Dispatch message handler is not gated behind a token check.
+//
+// When the app calls any of these:
+//   registerForPushNotifications()
+//   requestPushToken() / getPushToken()
+//   registerForRemoteNotifications(callback)
+//   getDeviceToken()
+//
+// We return a synthetic token that passes any string/non-null check but will
+// not deliver real APNs push messages (background delivery is a known
+// non-goal — the app must be running for Dispatch to function on Linux).
+// ---------------------------------------------------------------------------
+const LINUX_PUSH_TOKEN = 'linux-dispatch-stub-' + require('os').hostname().replace(/[^a-z0-9]/gi, '').slice(0, 16) + '-' + process.pid;
+
+function registerForPushNotifications(callback) {
+  process.stderr.write('[claude-native stub] registerForPushNotifications → synthetic token\n');
+  if (typeof callback === 'function') {
+    setImmediate(() => callback(null, LINUX_PUSH_TOKEN));
+  }
+  return Promise.resolve({ token: LINUX_PUSH_TOKEN, success: true, authorized: true });
+}
+
+function requestPushToken() {
+  process.stderr.write('[claude-native stub] requestPushToken → synthetic token\n');
+  return Promise.resolve({ token: LINUX_PUSH_TOKEN, success: true });
+}
+
+function getPushToken() {
+  return LINUX_PUSH_TOKEN;
+}
+
+function getDeviceToken() {
+  return Promise.resolve(LINUX_PUSH_TOKEN);
+}
+
+function requestNotificationAuthorization() {
+  return Promise.resolve({ authorized: true, granted: true });
+}
+
+function isPushNotificationsEnabled() { return true; }
+function isPushNotificationsRegistered() { return true; }
+
+// ---------------------------------------------------------------------------
 // AuthRequest — handles the claude:// OAuth deep-link callback.
 // Uses detached+stdio:ignore+unref so the opener does not block Electron.
 // ---------------------------------------------------------------------------
@@ -153,6 +201,10 @@ const _base = {
   KeyboardKey, getOSVersion, getPlatform, getPlatformName, getPlatformInfo,
   isCoworkSupported, getCoworkAvailability,
   isDispatchSupported, getDispatchAvailability, getFeatureAvailability,
+  // Push notification stubs for Dispatch
+  registerForPushNotifications, requestPushToken, getPushToken, getDeviceToken,
+  requestNotificationAuthorization,
+  isPushNotificationsEnabled, isPushNotificationsRegistered,
   AuthRequest,
 };
 


### PR DESCRIPTION
## Summary
Extended the platform-gate patching system to support multiple gate functions within a single bundle, enabling simultaneous patching of both Cowork and Dispatch gates. This is necessary because some builds contain separate gate functions for different features that must all be patched to enable full functionality.

## Key Changes

**find-platform-gate.mjs**
- Added `--all` flag to output all matches above threshold instead of just the single best match
- Changed output format to support both legacy single-gate `{ file, start, end }` and new multi-gate `{ gates: [...] }` formats
- Improved logging to distinguish between single and multi-gate modes

**apply-platform-gate.mjs**
- Refactored to accept and process multiple gates from either legacy or multi-gate JSON format
- Implemented per-file grouping with descending-order patching to preserve character offsets when multiple gates exist in the same file
- Enhanced error handling: gates with validation errors are now skipped with warnings instead of failing the entire operation
- Added detailed logging for each patched gate including original/replacement lengths and preview
- Exit with error only if no gates were successfully patched

**platform-override.js**
- Expanded `NEGATIVE_STATUSES` set to include update/download-related status values (`update_required`, `download_required`, `out_of_date`, `outdated`, `requires_update`, `update_available`, `needs_update`, `not_ready`)
- Added rewriting of boolean flags (`needsUpdate`, `updateRequired`, `downloadRequired`, `isUpdateAvailable`) to false in main process
- Updated renderer-side postMessage interception to handle the expanded status set and boolean flags
- Added new event listener for `dispatch-feature-check` custom event to unblock Dispatch message input

**stubs/claude-native.js**
- Added push notification stub functions required for Dispatch message delivery on Linux:
  - `registerForPushNotifications()`, `requestPushToken()`, `getPushToken()`, `getDeviceToken()`
  - `requestNotificationAuthorization()`, `isPushNotificationsEnabled()`, `isPushNotificationsRegistered()`
- Generates synthetic Linux-compatible push tokens to satisfy registration checks without enabling actual APNs delivery

**patches/native-frame.js**
- Simplified tray icon patching logic to always prefer the pre-resolved Linux-compatible icon
- Added `double-click` handler alongside `click` for better compatibility with KDE Plasma and other desktop environments
- Intercepted `setImage()` method to ensure post-construction icon updates also use the Linux-compatible icon

**scripts/patch-cowork.sh**
- Updated to pass `--all` flag to find-platform-gate.mjs for multi-gate discovery
- Simplified gate location extraction to handle both single and multi-gate JSON formats
- Updated logging and summary output to reflect multi-gate support

## Implementation Details
- When multiple gates exist in the same file, they are patched in descending offset order to prevent earlier patches from invalidating later character positions
- Malformed gate entries are logged and skipped rather than causing total failure, improving robustness
- The renderer-side status rewriting logic is duplicated (not shared with main process) because the renderer runs in a separate V8 context
- Push token generation includes hostname and PID for uniqueness while remaining deterministic for the same process

https://claude.ai/code/session_01TK6eqT7XcCQz4RbPXSMhv5