### PR TITLE
feat: enable Cowork and Dispatch on Linux via socket IPC

### DIFF
--- a/ARCHITECTURE.MD
+++ b/ARCHITECTURE.MD
@@ -268,6 +268,71 @@ processing untrusted third-party content in production.
 
 ---
 
+## Socket IPC Protocol
+
+Claude Desktop's Cowork and Dispatch features communicate with a backend daemon
+over a socket-based IPC protocol.  The protocol uses length-prefixed JSON
+messages: a 4-byte big-endian unsigned integer specifying the payload length,
+followed by the UTF-8 JSON payload.
+
+```
+macOS:   Desktop → @ant/claude-swift → VZVirtualMachine → vsock → sdk-daemon
+Windows: Desktop → cowork-svc.exe    → Named Pipe (\\.\\pipe\\cowork-vm-service) → Hyper-V VM → vsock → sdk-daemon
+Linux:   Desktop → Unix socket ($XDG_RUNTIME_DIR/cowork-vm-service.sock) → cowork-svc-linux → os/exec
+```
+
+On macOS and Windows the daemon runs inside a VM.  On Linux we skip the VM
+entirely: the `claude-cowork-service` daemon (MIT licensed, from
+`patrickjaja/claude-cowork-service`) listens on a Unix domain socket and
+delegates process management to `os/exec`.
+
+`patches/patch-cowork-socket.mjs` rewrites the app's named pipe path
+(`\\.\pipe\cowork-vm-service`) to a platform-aware expression that uses the
+Unix socket on Linux and preserves the named pipe on Windows.
+
+**Why we use the external daemon instead of reimplementing the protocol:**
+
+The socket protocol has 17+ methods and non-trivial lifecycle management
+(process tracking, stdin forwarding, event subscriptions).  The Go daemon
+already implements all of this correctly and is MIT-licensed.  Reimplementing
+in JS would duplicate effort and introduce bugs.  Our job is to make the
+Electron app connect to it — not to rewrite it.
+
+---
+
+## Dispatch on Linux
+
+Dispatch is Anthropic's mobile-to-desktop task delegation feature.  It uses
+server-sent events (SSE) for real-time delivery when the app is open, and
+push notifications (APNs/FCM) for background delivery when the app is closed.
+
+On Linux:
+
+1. **SSE delivery works** — when the app is open, Dispatch tasks arrive via
+   the same SSE connection used for other real-time features.
+2. **Push delivery does not work** — APNs is Apple-only, FCM requires a
+   registered application identity.  We do not attempt to register with either
+   service.
+
+To make Dispatch functional, several GrowthBook feature flags must be
+force-enabled.  `patches/patch-dispatch.mjs` finds these by their stable
+hash constants (which survive minification) and flips the associated boolean
+initializers:
+
+| Sub-patch | Hash constant | Purpose |
+|---|---|---|
+| A | `3572572142` | Sessions-bridge init gate |
+| B | `2216414644` | Remote session control check |
+| C | *(structural)* | Platform label ("Darwin"/"Windows" → add "Linux") |
+| D | `1143815894` | hostLoopMode — use native host paths instead of VM paths |
+
+Additionally, `stubs/dispatch-polyfill.js` registers IPC handlers for the
+Dispatch UI channels so the renderer can render the Dispatch panel without
+errors, and `patches/fix-dispatch-gate.mjs` patches any Dispatch-specific
+platform gate (separate from the Cowork gate).
+
+---
+
 ## Package Format Decisions
 
 ### RPM: system Electron, no bundle
@@ -363,8 +428,20 @@ Release body is auto-generated and includes:
 | `xdg-open` not available | OAuth flow broken | Runtime | Stub checks and falls back to printing the URL |
 | bubblewrap not installed | Cowork silently uses host backend | `--doctor` flag | Launcher warns; falls back to `host` |
 | DMG URL changed | `fetch-dmg.sh` exits 1 | CI fails | Update URL in `fetch-dmg.sh` |
+| `cowork-svc-linux` not running | Cowork/Dispatch socket features fail | Runtime | Launcher warns; `scripts/install-cowork-service.sh` |
+| GrowthBook flag hash changed | `patch-dispatch.mjs` finds 0 matches | CI warning | Update hash constants in `patch-dispatch.mjs` |
 
 ---
+
+## Partial Support
+
+**Dispatch — partially supported.** Dispatch works via SSE when the app is open.
+GrowthBook feature flags are force-enabled (`patches/patch-dispatch.mjs`), UI
+platform gates are bypassed, and IPC handlers are stubbed.  The
+`claude-cowork-service` daemon provides the socket backend that Dispatch's session
+management requires.  Background delivery (APNs/FCM push wake-up) is not
+available — tasks sent from mobile when the app is closed won't arrive until the
+next launch.  See "Dispatch on Linux" section above for details.
 
 ## Explicit Non-Goals
 
@@ -376,15 +453,6 @@ enable Cowork and serve the claude-code binary bundle — without them, Cowork n
 activates regardless of local patches.  Every working Linux Cowork implementation
 sends these headers.  We do NOT modify User-Agent strings, general browsing
 headers, or requests to any non-Anthropic domain.
-
-**Partial Dispatch.** Dispatch's mobile-to-desktop protocol uses push notifications
-via APNs (Apple) and FCM (Google) for background delivery. We bypass the UI
-platform gates (via IPC interception in `platform-override.js` and Dispatch stubs
-in `claude-native.js`) and polyfill the Electron Notification API so the Dispatch
-UI is available. However, tasks that rely on APNs/FCM push notifications to wake
-the desktop app when it is closed will not be delivered — the app must be running.
-Registering a real application identifier with Apple/Google push services or
-reverse-engineering the token exchange is not in scope.
 
 **No Computer Use.** Requires capturing the screen and injecting mouse/keyboard
 events. The current Cowork architecture on macOS uses `AXUIElement` (macOS

--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -25,6 +25,7 @@ entirely and run the Claude Code binary directly on the host.
 │   ├── extract-asar.sh          ← DMG → app.asar + detect versions
 │   ├── inject-stubs.sh          ← replace native modules with JS stubs
 │   ├── patch-cowork.sh          ← unlock Cowork on Linux
+│   ├── install-cowork-service.sh ← install claude-cowork-service daemon
 │   └── build-packages.sh        ← RPM + AppImage assembly
 ├── stubs/
 │   ├── claude-native.js         ← @ant/claude-native replacement
@@ -38,6 +39,9 @@ entirely and run the Claude Code binary directly on the host.
 │   ├── fix-tray-config.sh       ← ensure menuBarEnabled in user config
 │   ├── fix-bundle-download.mjs  ← AST patch for platform-gated binary download
 │   ├── fix-dispatch-gate.mjs    ← AST patch for Dispatch availability gate
+│   ├── patch-cowork-socket.mjs  ← AST patch: named pipe → Unix socket
+│   ├── patch-dispatch.mjs       ← AST patch: GrowthBook feature flag overrides
+│   ├── patch-computer-use-tcc.mjs ← AST injection of ComputerUseTcc stubs
 │   └── path-translator.js       ← /sessions/… → ~/.local/share/… remapping
 ├── packaging/
 │   ├── claude-desktop.spec      ← RPM spec file
@@ -79,6 +83,7 @@ entirely and run the Claude Code binary directly on the host.
 | `DISPATCH_DEBUG` | `` | Set to `1` for Dispatch IPC traffic logging |
 | `DISPATCH_POLL_INTERVAL_MS` | `30000` | Dispatch foreground polling interval (ms) |
 | `SKIP_DISPATCH_POLL` | `` | Set to `1` to disable Dispatch polling |
+| `SKIP_DISPATCH_PATCH` | `` | Set to `1` to skip Dispatch GrowthBook feature flag patches |
 
 ## Build Dependencies
 
@@ -95,6 +100,7 @@ Resolved at runtime if missing; the scripts will print install instructions.
 | `icns2png` or `magick` | Convert macOS icon to PNG |
 | `bubblewrap` (`bwrap`) | Cowork sandbox (runtime, not build) |
 | `electron` | Runtime; bundled inside AppImage |
+| `cowork-svc-linux` | Optional: Cowork/Dispatch socket daemon (runtime) |
 
 ## Key Files Inside the Extracted ASAR
 
@@ -260,6 +266,57 @@ KVM/QEMU is intentionally not implemented. Anthropic blocks VM image downloads
 for Linux; the infrastructure would be complex; and bubblewrap provides adequate
 isolation for personal use.
 
+## Socket IPC Protocol (Cowork/Dispatch daemon)
+
+Claude Desktop communicates with a backend daemon over a socket-based IPC
+protocol using length-prefixed JSON messages (4-byte big-endian length header
+followed by UTF-8 JSON payload).
+
+**Transport per platform:**
+
+```
+macOS:   Desktop → @ant/claude-swift → VZVirtualMachine → vsock → sdk-daemon
+Windows: Desktop → cowork-svc.exe    → Named Pipe       → Hyper-V VM → vsock → sdk-daemon
+Linux:   Desktop → Unix socket       → cowork-svc-linux  → os/exec (no VM)
+```
+
+On Linux the `claude-cowork-service` daemon (MIT, from
+`patrickjaja/claude-cowork-service`) listens on a Unix domain socket at
+`$XDG_RUNTIME_DIR/cowork-vm-service.sock` and handles process lifecycle
+directly via `os/exec` — no VM needed.
+
+**Known protocol methods** (length-prefixed JSON-RPC style):
+
+| Method | Description |
+|---|---|
+| `isRunning` | Check if the daemon is alive |
+| `vmStarted` | Check if the (virtual) environment is ready |
+| `apiReachable` | Check API connectivity |
+| `isGuestConnected` | Check if the guest agent is connected |
+| `subscribeEvents` | Subscribe to lifecycle events |
+| `writeStdin` | Write to a process's stdin |
+| `spawn` | Start a new process |
+| `kill` | Kill a running process |
+| `readFile` | Read a file from the session filesystem |
+| `writeFile` | Write a file to the session filesystem |
+| `listDir` | List directory contents |
+| `getSystemInfo` | Get system information |
+| `getNetworkInfo` | Get network configuration |
+| `ping` | Health check |
+| `shutdown` | Gracefully stop the daemon |
+| `getVersion` | Get daemon version |
+| `configure` | Update runtime configuration |
+
+**Installation:**
+
+```sh
+./scripts/install-cowork-service.sh
+```
+
+This downloads the pre-built binary, installs it to `~/.local/bin/`, creates
+a systemd user service, and verifies the socket appears.  The launcher scripts
+warn if the service is not running but do not block app launch.
+
 ## Packaging Notes
 
 ### RPM
@@ -308,14 +365,14 @@ version string. The DMG is never cached — always fetch fresh.
 
 ## What This Project Intentionally Does Not Do
 
-- **Partial Dispatch support.** Dispatch works while the app is in the
-  foreground. UI platform gates are bypassed, IPC handlers are stubbed
-  (`stubs/dispatch-polyfill.js`), and Electron's Notification API is polyfilled.
-  A foreground polling skeleton is in place but the polling endpoint has not yet
-  been discovered — set `DISPATCH_DEBUG=1` to log IPC traffic for reverse-
-  engineering.  Background delivery via APNs/FCM push notifications is not
-  available; tasks sent from mobile when the app is closed won't arrive until
-  next launch.
+- **Dispatch — partially supported.** Dispatch works via SSE when the app is
+  open.  GrowthBook feature flags are force-enabled by `patches/patch-dispatch.mjs`
+  (sessions-bridge init, remote session control, hostLoopMode).  UI platform gates
+  are bypassed, IPC handlers are stubbed (`stubs/dispatch-polyfill.js`), and
+  Electron's Notification API is polyfilled.  The `claude-cowork-service` daemon
+  provides the socket backend that Dispatch's session management requires.
+  Background delivery (APNs/FCM push wake-up) is not available; tasks sent from
+  mobile when the app is closed won't arrive until next launch.
 - **No Computer Use.** Requires `xdotool`/`scrot` hacks that are fragile and
   version-sensitive. Out of scope for the initial release.
 - **No KVM isolation.** See Cowork Isolation Backends above.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ See [ARCHITECTURE.MD](ARCHITECTURE.MD) for design decisions and trade-offs.
 - **MCP** — Model Context Protocol support works as-is (it is pure JS)
 - **Cowork (Claude Code)** — unlocked and functional via `bubblewrap` sandbox
   or direct host execution
+- **Dispatch** — partially supported; works via SSE when the app is open
+  (requires `claude-cowork-service` daemon — see below)
 - **Auto-update pipeline** — GitHub Actions polls for new releases every 6 hours
   and publishes automatically; AppImage supports delta updates via `AppImageUpdate`
 
@@ -43,7 +45,7 @@ See [ARCHITECTURE.MD](ARCHITECTURE.MD) for design decisions and trade-offs.
 
 | Feature | Reason |
 |---|---|
-| **Dispatch** | Partially supported — UI gates are bypassed and notifications polyfilled, but background delivery via APNs/FCM is not available; Dispatch tasks that rely on push notifications to wake the desktop app will not arrive when the app is closed |
+| **Dispatch** | Partially supported — works via SSE when the app is open; GrowthBook feature flags are force-enabled and `claude-cowork-service` provides the socket backend; background delivery (APNs/FCM push) is not available so tasks won't arrive when the app is closed |
 | **Computer Use** | macOS implementation uses `AXUIElement`; an `xdotool`/`scrot` replacement would be fragile across desktop environments |
 | **ARM64** | Electron binary selection and AppImage build are x86_64 only; ARM64 is a future milestone |
 
@@ -188,6 +190,21 @@ Pre-built Nix-compatible tarballs are available in each GitHub Release:
 # Download and extract
 curl -fLO https://github.com/stslex/claude-desktop-linux/releases/latest/download/claude-desktop-<version>-repack-<N>-x86_64-nix.tar.gz
 ```
+
+### Cowork Service (optional — enables Cowork and Dispatch)
+
+The `claude-cowork-service` daemon provides the socket backend that Cowork and
+Dispatch use for session management.  Install it for full Cowork/Dispatch support:
+
+```sh
+./scripts/install-cowork-service.sh
+```
+
+This downloads the pre-built binary from
+[patrickjaja/claude-cowork-service](https://github.com/patrickjaja/claude-cowork-service),
+installs it to `~/.local/bin/`, and creates a systemd user service.  The app
+will warn on launch if the service is not running, but Chat and MCP still work
+without it.
 
 ### First Run
 

--- a/packaging/AppDir/AppRun
+++ b/packaging/AppDir/AppRun
@@ -43,6 +43,15 @@ if [[ ! -L /sessions ]]; then
 fi
 
 # ---------------------------------------------------------------------------
+# Cowork service check (optional — Cowork/Dispatch via socket protocol).
+# ---------------------------------------------------------------------------
+if ! pgrep -x cowork-svc-linux &>/dev/null && \
+   ! systemctl --user is-active claude-cowork &>/dev/null 2>&1; then
+  echo "[claude-desktop] WARN: claude-cowork service not running. Cowork features will not work." >&2
+  echo "  Run: scripts/install-cowork-service.sh" >&2
+fi
+
+# ---------------------------------------------------------------------------
 # Cowork backend selection.
 # ---------------------------------------------------------------------------
 COWORK_BACKEND="${COWORK_BACKEND:-bubblewrap}"

--- a/packaging/AppDir/usr/bin/claude-desktop
+++ b/packaging/AppDir/usr/bin/claude-desktop
@@ -66,6 +66,15 @@ if [[ -z "$ELECTRON" ]]; then
 fi
 
 # ---------------------------------------------------------------------------
+# Cowork service check (optional — Cowork/Dispatch via socket protocol).
+# ---------------------------------------------------------------------------
+if ! pgrep -x cowork-svc-linux &>/dev/null && \
+   ! systemctl --user is-active claude-cowork &>/dev/null 2>&1; then
+    echo "[claude-desktop] WARN: claude-cowork service not running. Cowork features will not work." >&2
+    echo "  Run: scripts/install-cowork-service.sh" >&2
+fi
+
+# ---------------------------------------------------------------------------
 # Cowork backend selection.
 # ---------------------------------------------------------------------------
 COWORK_BACKEND="${COWORK_BACKEND:-bubblewrap}"

--- a/packaging/claude-desktop.spec
+++ b/packaging/claude-desktop.spec
@@ -36,6 +36,8 @@ Requires:       gtk3
 Requires:       glib2
 Requires:       pango
 
+Suggests:       cowork-svc-linux
+
 # Source0: patched app.asar (produced by build-rpm.sh)
 # Source1: launcher script
 # Source2: freedesktop .desktop file

--- a/patches/patch-computer-use-tcc.mjs
+++ b/patches/patch-computer-use-tcc.mjs
@@ -1,0 +1,248 @@
+/**
+ * patch-computer-use-tcc.mjs
+ *
+ * AST-based patch that injects ComputerUseTcc IPC handler stubs directly into
+ * the main process bundle.  This complements stubs/ipc-stubs.js (which
+ * registers handlers at module load time) by also patching any inline
+ * ComputerUseTcc references in the bundle that might fire before the stubs
+ * are loaded.
+ *
+ * What it does:
+ *   1. Finds ipcMain.handle() registration sites in the bundle
+ *   2. Adds ComputerUseTcc handler registrations nearby
+ *   3. Finds any ComputerUseTcc.getState / requestAccess calls in the
+ *      renderer preload and ensures they have fallback values
+ *
+ * If no suitable injection site is found (the existing stubs/ipc-stubs.js
+ * handles it at runtime), this patch exits 0 gracefully.
+ *
+ * Usage:
+ *   node patches/patch-computer-use-tcc.mjs <app-extracted-dir>
+ */
+
+import { readFileSync, writeFileSync, readdirSync } from 'fs';
+import { join, relative } from 'path';
+import * as acorn from 'acorn';
+import * as walk from 'acorn-walk';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+const TCC_CHANNELS = [
+  'ComputerUseTcc:getState',
+  'ComputerUseTcc:requestAccess',
+  'ComputerUseTcc.getState',
+  'ComputerUseTcc.requestPermission',
+  'ComputerUseTcc.checkAccessibility',
+  'ComputerUseTcc.checkScreenRecording',
+  'ComputerUseTcc.requestAccessibility',
+  'ComputerUseTcc.requestScreenRecording',
+];
+
+const STUB_SNIPPET = `
+;(function(){try{var e=require("electron"),m=e.ipcMain;if(m){
+var ch=["ComputerUseTcc:getState","ComputerUseTcc:requestAccess",
+"ComputerUseTcc.getState","ComputerUseTcc.requestPermission",
+"ComputerUseTcc.checkAccessibility","ComputerUseTcc.checkScreenRecording",
+"ComputerUseTcc.requestAccessibility","ComputerUseTcc.requestScreenRecording"];
+var r={status:"not_applicable"};
+ch.forEach(function(c){try{m.handle(c,function(){return r})}catch(x){}});
+}}catch(x){}})();`;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+const log = (msg) => process.stderr.write(`[patch-computer-use-tcc] ${msg}\n`);
+
+function collectJsFiles(dir) {
+  const files = [];
+  try {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        files.push(...collectJsFiles(full));
+      } else if (entry.name.endsWith('.js')) {
+        files.push(full);
+      }
+    }
+  } catch (e) {
+    log(`WARNING: Cannot read ${dir}: ${e.message}`);
+  }
+  return files;
+}
+
+function tryParse(src, file) {
+  for (const sourceType of ['module', 'script']) {
+    try {
+      return acorn.parse(src, {
+        ecmaVersion: 'latest',
+        sourceType,
+      });
+    } catch (_) {}
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+const appDir = process.argv[2];
+if (!appDir) {
+  log('Usage: node patches/patch-computer-use-tcc.mjs <app-extracted-dir>');
+  process.exit(1);
+}
+
+const viteDir = join(appDir, '.vite', 'build');
+const scanDirs = [viteDir, appDir];
+
+log('Scanning for ComputerUseTcc references...');
+
+let tccRefCount = 0;
+let ipcHandleSites = []; // { file, src, offset }
+let tccStringRefs = []; // { file, relFile, value, offset }
+
+for (const scanDir of scanDirs) {
+  const files = collectJsFiles(scanDir);
+
+  for (const file of files) {
+    let src;
+    try {
+      src = readFileSync(file, 'utf8');
+    } catch {
+      continue;
+    }
+
+    if (!src.includes('ComputerUseTcc') && !src.includes('ipcMain')) continue;
+
+    const ast = tryParse(src, file);
+    if (!ast) continue;
+
+    const relFile = relative(appDir, file);
+
+    walk.simple(ast, {
+      Literal(node) {
+        if (typeof node.value !== 'string') return;
+
+        // Track ComputerUseTcc string references
+        if (node.value.includes('ComputerUseTcc')) {
+          tccStringRefs.push({
+            file,
+            relFile,
+            value: node.value,
+            offset: node.start,
+          });
+          tccRefCount++;
+        }
+      },
+      CallExpression(node) {
+        // Track ipcMain.handle() call sites
+        if (
+          node.callee &&
+          node.callee.type === 'MemberExpression' &&
+          node.callee.property &&
+          (node.callee.property.name === 'handle' ||
+            node.callee.property.value === 'handle')
+        ) {
+          const callerSrc = src.slice(
+            Math.max(0, node.start - 50),
+            node.start,
+          );
+          if (callerSrc.includes('ipcMain') || callerSrc.includes('ipc')) {
+            ipcHandleSites.push({
+              file,
+              relFile,
+              offset: node.start,
+            });
+          }
+        }
+      },
+    });
+  }
+
+  if (tccRefCount > 0 || ipcHandleSites.length > 0) break;
+}
+
+// ---------------------------------------------------------------------------
+// Report findings
+// ---------------------------------------------------------------------------
+log(`Found ${tccStringRefs.length} ComputerUseTcc string reference(s):`);
+for (const ref of tccStringRefs) {
+  log(`  ${ref.relFile} [${ref.offset}]: "${ref.value}"`);
+}
+
+log(`Found ${ipcHandleSites.length} ipcMain.handle() call site(s)`);
+
+// ---------------------------------------------------------------------------
+// Strategy decision
+// ---------------------------------------------------------------------------
+// The runtime stubs/ipc-stubs.js already handles ComputerUseTcc at module
+// load time.  This AST patch adds a belt-and-suspenders injection directly
+// into the main bundle, near existing ipcMain.handle() calls.
+//
+// If we find ipcMain.handle() sites in the main bundle (index.js), we inject
+// our stub snippet right before the first one.
+// If not, we prepend it to the main entry point file.
+
+let patched = false;
+
+// Preferred: inject near existing ipcMain.handle() in the main bundle
+const mainBundle = join(viteDir, 'index.js');
+let mainBundleSite = ipcHandleSites.find((s) => s.file === mainBundle);
+
+if (mainBundleSite) {
+  let src = readFileSync(mainBundle, 'utf8');
+
+  // Check if our stubs are already injected
+  if (src.includes('ComputerUseTcc:getState') && src.includes('not_applicable')) {
+    log('ComputerUseTcc stubs already present in main bundle — skipping.');
+  } else {
+    // Inject before the first ipcMain.handle() call
+    const injectionPoint = mainBundleSite.offset;
+    const result = src.slice(0, injectionPoint) + STUB_SNIPPET + src.slice(injectionPoint);
+    writeFileSync(mainBundle, result, 'utf8');
+    log(`Injected ComputerUseTcc stubs at offset ${injectionPoint} in ${relative(appDir, mainBundle)}`);
+    log(`File size: ${src.length} → ${result.length} bytes`);
+    patched = true;
+  }
+} else {
+  // Fallback: check if the main entry exists and prepend
+  let mainEntry = mainBundle;
+  try {
+    readFileSync(mainEntry, 'utf8');
+  } catch {
+    // Try package.json main field
+    try {
+      const pkg = JSON.parse(readFileSync(join(appDir, 'package.json'), 'utf8'));
+      if (pkg.main) {
+        mainEntry = join(appDir, pkg.main);
+      }
+    } catch {}
+  }
+
+  try {
+    let src = readFileSync(mainEntry, 'utf8');
+    if (src.includes('ComputerUseTcc:getState') && src.includes('not_applicable')) {
+      log('ComputerUseTcc stubs already present — skipping.');
+    } else {
+      const result = STUB_SNIPPET + '\n' + src;
+      writeFileSync(mainEntry, result, 'utf8');
+      log(`Prepended ComputerUseTcc stubs to ${relative(appDir, mainEntry)}`);
+      log(`File size: ${src.length} → ${result.length} bytes`);
+      patched = true;
+    }
+  } catch (e) {
+    log(`WARNING: Could not read main entry ${mainEntry}: ${e.message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+if (patched) {
+  log('ComputerUseTcc IPC stubs injected into main bundle.');
+} else {
+  log('No AST injection needed — runtime stubs (ipc-stubs.js) will handle ComputerUseTcc.');
+}
+
+// Always exit 0 — the runtime stubs provide a safety net
+process.exit(0);

--- a/patches/patch-cowork-socket.mjs
+++ b/patches/patch-cowork-socket.mjs
@@ -1,0 +1,402 @@
+/**
+ * patch-cowork-socket.mjs
+ *
+ * AST-based patch that redirects the Cowork VM client's transport endpoint
+ * from a Windows named pipe to a Linux Unix domain socket.
+ *
+ * On Windows, the app connects to: \\.\pipe\cowork-vm-service
+ * On Linux, we redirect to:       $XDG_RUNTIME_DIR/cowork-vm-service.sock
+ *
+ * The patch also ensures that any `process.platform === 'win32'` or
+ * `process.platform === 'darwin'` guards on the VM client class accept
+ * 'linux' as well.
+ *
+ * Usage:
+ *   node patches/patch-cowork-socket.mjs <app-extracted-dir>
+ *
+ * Exits 0 on success, 1 if the pattern is not found.
+ */
+
+import { readFileSync, writeFileSync, readdirSync, statSync } from 'fs';
+import { join, relative } from 'path';
+import * as acorn from 'acorn';
+import * as walk from 'acorn-walk';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+const PIPE_PATTERNS = [
+  'cowork-vm-service',
+  '\\\\.\\pipe\\',
+  '\\\\\\\\.\\\\pipe\\\\',
+  'pipe\\cowork',
+];
+
+const SOCKET_REPLACEMENT =
+  `(process.platform==="linux"` +
+  `?(process.env.XDG_RUNTIME_DIR||"/run/user/"+process.getuid())+"/cowork-vm-service.sock"` +
+  `:"\\\\\\\\.\\\\pipe\\\\cowork-vm-service")`;
+
+const PLATFORM_LINUX_ADDITION = `||process.platform==="linux"`;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+const log = (msg) => process.stderr.write(`[patch-cowork-socket] ${msg}\n`);
+
+function collectJsFiles(dir) {
+  const files = [];
+  try {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        files.push(...collectJsFiles(full));
+      } else if (entry.name.endsWith('.js')) {
+        files.push(full);
+      }
+    }
+  } catch (e) {
+    log(`WARNING: Cannot read ${dir}: ${e.message}`);
+  }
+  return files;
+}
+
+function tryParse(src, file) {
+  for (const sourceType of ['module', 'script']) {
+    try {
+      return acorn.parse(src, {
+        ecmaVersion: 'latest',
+        sourceType,
+        locations: true,
+      });
+    } catch (_) {
+      // try next sourceType
+    }
+  }
+  log(`WARNING: Could not parse ${file} — skipping.`);
+  return null;
+}
+
+function collectStrings(node) {
+  const strings = new Set();
+  walk.simple(node, {
+    Literal(n) {
+      if (typeof n.value === 'string') strings.add(n.value);
+    },
+    TemplateLiteral(n) {
+      for (const q of n.quasis) {
+        if (q.value && q.value.raw) strings.add(q.value.raw);
+      }
+    },
+  });
+  return strings;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+const appDir = process.argv[2];
+if (!appDir) {
+  log('Usage: node patches/patch-cowork-socket.mjs <app-extracted-dir>');
+  process.exit(1);
+}
+
+const viteDir = join(appDir, '.vite', 'build');
+let scanDirs = [viteDir, appDir];
+
+log(`Scanning for cowork socket transport patterns...`);
+
+// ---------------------------------------------------------------------------
+// Phase 1: Find files containing pipe/cowork-vm-service references
+// ---------------------------------------------------------------------------
+let pipeMatches = []; // { file, src, offset, literal, context }
+let platformGuardMatches = []; // { file, src, offset, context }
+
+for (const scanDir of scanDirs) {
+  const files = collectJsFiles(scanDir);
+
+  for (const file of files) {
+    let src;
+    try {
+      src = readFileSync(file, 'utf8');
+    } catch {
+      continue;
+    }
+
+    // Quick text check before parsing
+    const hasPipeRef = PIPE_PATTERNS.some((p) => src.includes(p));
+    const hasPlatformGuard =
+      src.includes('cowork') &&
+      (src.includes('process.platform') || src.includes('"win32"'));
+
+    if (!hasPipeRef && !hasPlatformGuard) continue;
+
+    const ast = tryParse(src, file);
+    if (!ast) continue;
+
+    const relFile = relative(appDir, file);
+
+    // Find pipe path string literals
+    if (hasPipeRef) {
+      walk.simple(ast, {
+        Literal(node) {
+          if (typeof node.value !== 'string') return;
+          const val = node.value;
+          if (
+            val.includes('cowork-vm-service') ||
+            val.includes('\\\\.\\pipe\\') ||
+            val.includes('\\\\pipe\\')
+          ) {
+            pipeMatches.push({
+              file,
+              relFile,
+              src,
+              start: node.start,
+              end: node.end,
+              literal: val,
+              raw: src.slice(node.start, node.end),
+            });
+          }
+        },
+        TemplateLiteral(node) {
+          for (const q of node.quasis) {
+            if (
+              q.value &&
+              q.value.raw &&
+              (q.value.raw.includes('cowork-vm-service') ||
+                q.value.raw.includes('\\\\.\\pipe\\'))
+            ) {
+              pipeMatches.push({
+                file,
+                relFile,
+                src,
+                start: node.start,
+                end: node.end,
+                literal: q.value.raw,
+                raw: src.slice(node.start, node.end),
+              });
+            }
+          }
+        },
+      });
+    }
+
+    // Find platform guards near cowork references
+    if (hasPlatformGuard) {
+      walk.ancestor(ast, {
+        BinaryExpression(node, _state, ancestors) {
+          // Look for: process.platform === "win32" or process.platform === "darwin"
+          if (node.operator !== '===' && node.operator !== '==') return;
+
+          const isProcessPlatform =
+            (node.left.type === 'MemberExpression' &&
+              node.left.object &&
+              node.left.object.name === 'process' &&
+              node.left.property &&
+              node.left.property.name === 'platform') ||
+            (node.right.type === 'MemberExpression' &&
+              node.right.object &&
+              node.right.object.name === 'process' &&
+              node.right.property &&
+              node.right.property.name === 'platform');
+
+          if (!isProcessPlatform) return;
+
+          const platformValue =
+            (node.left.type === 'Literal' && typeof node.left.value === 'string'
+              ? node.left.value
+              : null) ||
+            (node.right.type === 'Literal' &&
+            typeof node.right.value === 'string'
+              ? node.right.value
+              : null);
+
+          if (
+            platformValue !== 'win32' &&
+            platformValue !== 'darwin'
+          )
+            return;
+
+          // Check if this is near cowork-related code by examining enclosing function
+          const enclosingFn = [...ancestors]
+            .reverse()
+            .find(
+              (a) =>
+                a.type === 'FunctionDeclaration' ||
+                a.type === 'FunctionExpression' ||
+                a.type === 'ArrowFunctionExpression',
+            );
+
+          if (!enclosingFn) return;
+
+          const fnStrings = collectStrings(enclosingFn);
+          const isCoworkRelated = [...fnStrings].some(
+            (s) =>
+              s.includes('cowork') ||
+              s.includes('vm-service') ||
+              s.includes('vmStarted') ||
+              s.includes('apiReachable') ||
+              s.includes('subscribeEvents') ||
+              s.includes('writeStdin') ||
+              s.includes('isGuestConnected'),
+          );
+
+          if (!isCoworkRelated) return;
+
+          platformGuardMatches.push({
+            file,
+            relFile,
+            src,
+            start: node.start,
+            end: node.end,
+            platformValue,
+            raw: src.slice(node.start, node.end),
+            fnStart: enclosingFn.start,
+            fnEnd: enclosingFn.end,
+          });
+        },
+      });
+    }
+  }
+
+  // If we found matches in the first scan dir, no need to scan more broadly
+  if (pipeMatches.length > 0) break;
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2: Report findings
+// ---------------------------------------------------------------------------
+log(`Found ${pipeMatches.length} pipe path reference(s)`);
+for (const m of pipeMatches) {
+  log(`  ${m.relFile} [${m.start}..${m.end}]: ${m.raw}`);
+}
+
+log(`Found ${platformGuardMatches.length} platform guard(s) near cowork code`);
+for (const m of platformGuardMatches) {
+  log(`  ${m.relFile} [${m.start}..${m.end}]: ${m.raw}`);
+}
+
+if (pipeMatches.length === 0 && platformGuardMatches.length === 0) {
+  log('ERROR: No cowork socket transport patterns found.');
+  log('Searching for any string containing "cowork" or "pipe" for diagnostics...');
+
+  for (const scanDir of scanDirs) {
+    const files = collectJsFiles(scanDir);
+    for (const file of files) {
+      let src;
+      try {
+        src = readFileSync(file, 'utf8');
+      } catch {
+        continue;
+      }
+      if (!src.includes('cowork') && !src.includes('pipe')) continue;
+
+      const ast = tryParse(src, file);
+      if (!ast) continue;
+
+      const relFile = relative(appDir, file);
+      const matches = [];
+      walk.simple(ast, {
+        Literal(node) {
+          if (typeof node.value !== 'string') return;
+          if (
+            node.value.includes('cowork') ||
+            (node.value.includes('pipe') && node.value.length < 100)
+          ) {
+            matches.push(`  [${node.start}] ${JSON.stringify(node.value)}`);
+          }
+        },
+      });
+      if (matches.length > 0) {
+        log(`Diagnostic — ${relFile}:`);
+        for (const m of matches) log(m);
+      }
+    }
+  }
+
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3: Apply patches
+// ---------------------------------------------------------------------------
+// Group patches by file
+const patchesByFile = new Map();
+
+for (const m of pipeMatches) {
+  if (!patchesByFile.has(m.file)) {
+    patchesByFile.set(m.file, { src: m.src, patches: [] });
+  }
+  patchesByFile.get(m.file).patches.push({
+    type: 'pipe-redirect',
+    start: m.start,
+    end: m.end,
+    replacement: SOCKET_REPLACEMENT,
+    description: `Pipe path "${m.literal}" → platform-aware socket/pipe`,
+  });
+}
+
+for (const m of platformGuardMatches) {
+  if (!patchesByFile.has(m.file)) {
+    patchesByFile.set(m.file, { src: m.src, patches: [] });
+  }
+
+  // For platform guards like `process.platform === "win32"` or `=== "darwin"`,
+  // wrap with `(original || process.platform === "linux")`
+  patchesByFile.get(m.file).patches.push({
+    type: 'platform-guard',
+    start: m.start,
+    end: m.end,
+    replacement: `(${m.raw}${PLATFORM_LINUX_ADDITION})`,
+    description: `Platform guard: ${m.raw} → includes linux`,
+  });
+}
+
+let totalPatched = 0;
+
+for (const [file, { src, patches }] of patchesByFile) {
+  const relFile = relative(appDir, file);
+
+  // Deduplicate overlapping ranges — keep the longer (more specific) patch
+  const sorted = patches.sort((a, b) => a.start - b.start);
+  const deduped = [];
+  for (const p of sorted) {
+    const last = deduped[deduped.length - 1];
+    if (last && p.start >= last.start && p.end <= last.end) {
+      // p is contained within last — skip if same type
+      if (p.type === last.type) continue;
+    }
+    if (last && p.start < last.end) {
+      // Overlapping — keep the pipe-redirect over platform-guard
+      if (p.type === 'pipe-redirect') {
+        deduped[deduped.length - 1] = p;
+      }
+      continue;
+    }
+    deduped.push(p);
+  }
+
+  // Apply patches from end to start to preserve offsets
+  let patched = src;
+  const reversed = deduped.sort((a, b) => b.start - a.start);
+
+  for (const p of reversed) {
+    log(`Applying ${p.type}: ${p.description}`);
+    patched = patched.slice(0, p.start) + p.replacement + patched.slice(p.end);
+    totalPatched++;
+  }
+
+  writeFileSync(file, patched, 'utf8');
+  log(`Wrote ${relFile} (${src.length} → ${patched.length} bytes)`);
+}
+
+// ---------------------------------------------------------------------------
+// If no pipe matches but we found platform guards, that's still useful
+// ---------------------------------------------------------------------------
+if (pipeMatches.length === 0 && platformGuardMatches.length > 0) {
+  log('NOTE: No pipe path found (may already use a different transport).');
+  log('Applied platform guard patches only.');
+}
+
+log(`Done. Applied ${totalPatched} patch(es).`);
+process.exit(0);

--- a/patches/patch-dispatch.mjs
+++ b/patches/patch-dispatch.mjs
@@ -1,0 +1,570 @@
+/**
+ * patch-dispatch.mjs
+ *
+ * AST-based patches that force-enable GrowthBook feature flags required for
+ * Dispatch on Linux.  These flags are hash constants that appear as plain
+ * numeric literals in the minified JS.
+ *
+ * Sub-patches:
+ *   A) Sessions-bridge init gate   (hash: 3572572142)
+ *   B) Remote session control check (hash: 2216414644)
+ *   C) Platform label               (function returning "Darwin"/"Windows" for platform)
+ *   D) hostLoopMode                 (hash: 1143815894)
+ *
+ * Usage:
+ *   node patches/patch-dispatch.mjs <app-extracted-dir>
+ *
+ * Exits 0 on success, 1 if critical sub-patches fail.
+ */
+
+import { readFileSync, writeFileSync, readdirSync, statSync } from 'fs';
+import { join, relative } from 'path';
+import * as acorn from 'acorn';
+import * as walk from 'acorn-walk';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+const FLAG_HASHES = {
+  sessionsBridge: 3572572142,
+  remoteSessionControl: 2216414644,
+  hostLoopMode: 1143815894,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+const log = (msg) => process.stderr.write(`[patch-dispatch] ${msg}\n`);
+
+function collectJsFiles(dir) {
+  const files = [];
+  try {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        files.push(...collectJsFiles(full));
+      } else if (entry.name.endsWith('.js')) {
+        files.push(full);
+      }
+    }
+  } catch (e) {
+    log(`WARNING: Cannot read ${dir}: ${e.message}`);
+  }
+  return files;
+}
+
+function tryParse(src, file) {
+  for (const sourceType of ['module', 'script']) {
+    try {
+      return acorn.parse(src, {
+        ecmaVersion: 'latest',
+        sourceType,
+        locations: true,
+      });
+    } catch (_) {
+      // try next sourceType
+    }
+  }
+  log(`WARNING: Could not parse ${file} — skipping.`);
+  return null;
+}
+
+/**
+ * Walk ancestors to find the nearest enclosing scope (function or block).
+ */
+function findEnclosingScope(ancestors) {
+  for (let i = ancestors.length - 1; i >= 0; i--) {
+    const a = ancestors[i];
+    if (
+      a.type === 'FunctionDeclaration' ||
+      a.type === 'FunctionExpression' ||
+      a.type === 'ArrowFunctionExpression' ||
+      a.type === 'BlockStatement'
+    ) {
+      return a;
+    }
+  }
+  return null;
+}
+
+/**
+ * Find a nearby boolean init (`!1` or `!0`) within a scope.
+ * Returns { start, end, currentValue } or null.
+ *
+ * "Nearby" means: within the same function/block scope as the flag hash literal.
+ * The boolean is typically in a VariableDeclarator init or an assignment.
+ */
+function findNearbyBooleanInit(ast, src, flagNode, scope) {
+  const candidates = [];
+
+  walk.simple(scope, {
+    UnaryExpression(node) {
+      // Match `!0` (true) or `!1` (false)
+      if (
+        node.operator === '!' &&
+        node.argument &&
+        node.argument.type === 'Literal' &&
+        (node.argument.value === 0 || node.argument.value === 1)
+      ) {
+        candidates.push({
+          start: node.start,
+          end: node.end,
+          currentValue: node.argument.value === 0, // !0 = true, !1 = false
+          raw: src.slice(node.start, node.end),
+        });
+      }
+    },
+  });
+
+  if (candidates.length === 0) return null;
+
+  // Find the closest boolean init to the flag hash.
+  // Prefer `!1` (false) since we want to flip false→true.
+  const falseCandidates = candidates.filter((c) => !c.currentValue);
+
+  // Pick the closest one to the flag literal by offset distance
+  const target = flagNode.start;
+  const pool = falseCandidates.length > 0 ? falseCandidates : candidates;
+  pool.sort((a, b) => Math.abs(a.start - target) - Math.abs(b.start - target));
+
+  return pool[0] || null;
+}
+
+/**
+ * Find a conditional expression that uses the result of a call containing
+ * the flag hash, and make it evaluate to the desired value.
+ */
+function findConditionalNearFlag(ast, src, flagNode, scope) {
+  const candidates = [];
+
+  walk.ancestor(scope, {
+    ConditionalExpression(node, _state, ancestors) {
+      // Check if the test references code near our flag
+      const testSrc = src.slice(node.test.start, node.test.end);
+      if (
+        Math.abs(node.start - flagNode.start) < 2000 &&
+        node.test.type === 'UnaryExpression' &&
+        node.test.operator === '!'
+      ) {
+        candidates.push({
+          type: 'conditional-test',
+          start: node.test.start,
+          end: node.test.end,
+          raw: testSrc,
+        });
+      }
+    },
+    IfStatement(node, _state, ancestors) {
+      const testSrc = src.slice(node.test.start, node.test.end);
+      if (
+        Math.abs(node.start - flagNode.start) < 2000 &&
+        node.test.type === 'UnaryExpression' &&
+        node.test.operator === '!'
+      ) {
+        candidates.push({
+          type: 'if-test',
+          start: node.test.start,
+          end: node.test.end,
+          raw: testSrc,
+        });
+      }
+    },
+  });
+
+  return candidates[0] || null;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+const appDir = process.argv[2];
+if (!appDir) {
+  log('Usage: node patches/patch-dispatch.mjs <app-extracted-dir>');
+  process.exit(1);
+}
+
+const viteDir = join(appDir, '.vite', 'build');
+const scanDirs = [viteDir, appDir];
+
+log('Scanning for Dispatch feature flag patterns...');
+
+// ---------------------------------------------------------------------------
+// Phase 1: Find all files containing our flag hashes
+// ---------------------------------------------------------------------------
+const flagLocations = new Map(); // hash → [{ file, src, ast, node, scope }]
+
+for (const hash of Object.values(FLAG_HASHES)) {
+  flagLocations.set(hash, []);
+}
+
+// Also track platform label function candidates
+const platformLabelCandidates = []; // { file, src, fnNode }
+
+for (const scanDir of scanDirs) {
+  const files = collectJsFiles(scanDir);
+
+  for (const file of files) {
+    let src;
+    try {
+      src = readFileSync(file, 'utf8');
+    } catch {
+      continue;
+    }
+
+    // Quick text filter
+    const hasAnyHash = Object.values(FLAG_HASHES).some((h) =>
+      src.includes(String(h)),
+    );
+    const hasPlatformLabel =
+      src.includes('"darwin"') ||
+      src.includes('"Darwin"') ||
+      src.includes('"win32"');
+
+    if (!hasAnyHash && !hasPlatformLabel) continue;
+
+    const ast = tryParse(src, file);
+    if (!ast) continue;
+
+    const relFile = relative(appDir, file);
+
+    // Find flag hash literals
+    if (hasAnyHash) {
+      walk.ancestor(ast, {
+        Literal(node, _state, ancestors) {
+          if (typeof node.value !== 'number') return;
+          const locations = flagLocations.get(node.value);
+          if (!locations) return;
+
+          const scope = findEnclosingScope(ancestors);
+          locations.push({
+            file,
+            relFile,
+            src,
+            ast,
+            node,
+            scope,
+            ancestors: [...ancestors],
+          });
+        },
+      });
+    }
+
+    // Find platform label function (Sub-patch C)
+    // A function containing "darwin" and "win32" that returns a string like
+    // "Darwin", "Windows", "macOS", etc.
+    if (hasPlatformLabel) {
+      walk.simple(ast, {
+        FunctionDeclaration(node) {
+          checkPlatformLabelFn(node, file, relFile, src);
+        },
+        FunctionExpression(node) {
+          checkPlatformLabelFn(node, file, relFile, src);
+        },
+        ArrowFunctionExpression(node) {
+          checkPlatformLabelFn(node, file, relFile, src);
+        },
+      });
+    }
+  }
+
+  // Check if we found all hashes in this scan dir
+  const allFound = [...flagLocations.values()].every((l) => l.length > 0);
+  if (allFound && platformLabelCandidates.length > 0) break;
+}
+
+function checkPlatformLabelFn(node, file, relFile, src) {
+  if (!node.body) return;
+
+  const body = node.body.type === 'BlockStatement' ? node.body : node.body;
+  const fnSrc = src.slice(node.start, node.end);
+
+  // Must contain both "darwin" and "win32"
+  if (!fnSrc.includes('"darwin"') && !fnSrc.includes("'darwin'")) return;
+  if (!fnSrc.includes('"win32"') && !fnSrc.includes("'win32'")) return;
+
+  // Must return a string (look for return statements with string literals)
+  const strings = new Set();
+  walk.simple(body.type === 'BlockStatement' ? body : { type: 'ExpressionStatement', expression: body }, {
+    ReturnStatement(n) {
+      if (n.argument && n.argument.type === 'Literal' && typeof n.argument.value === 'string') {
+        strings.add(n.argument.value);
+      }
+    },
+  });
+
+  // Should NOT return { status: ... } objects (that's the Cowork gate)
+  let hasStatusReturn = false;
+  walk.simple(body.type === 'BlockStatement' ? body : { type: 'ExpressionStatement', expression: body }, {
+    ReturnStatement(n) {
+      if (
+        n.argument &&
+        n.argument.type === 'ObjectExpression' &&
+        n.argument.properties &&
+        n.argument.properties.some(
+          (p) => p.key && (p.key.name === 'status' || p.key.value === 'status'),
+        )
+      ) {
+        hasStatusReturn = true;
+      }
+    },
+  });
+
+  if (hasStatusReturn) return;
+
+  // Must return at least one human-readable platform name
+  const platformNames = ['Darwin', 'Windows', 'macOS', 'Mac', 'Win'];
+  const hasPlatformName = [...strings].some((s) =>
+    platformNames.some((pn) => s.includes(pn)),
+  );
+
+  if (!hasPlatformName && strings.size === 0) return;
+
+  // Compact: < 500 chars
+  if (fnSrc.length > 500) return;
+
+  platformLabelCandidates.push({
+    file,
+    relFile,
+    src,
+    fnNode: node,
+    bodyNode: body,
+    strings,
+    fnSrc,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2: Report findings
+// ---------------------------------------------------------------------------
+const subPatchResults = {
+  A: { name: 'sessions-bridge', hash: FLAG_HASHES.sessionsBridge, applied: false },
+  B: { name: 'remote-session-control', hash: FLAG_HASHES.remoteSessionControl, applied: false },
+  C: { name: 'platform-label', hash: null, applied: false },
+  D: { name: 'hostLoopMode', hash: FLAG_HASHES.hostLoopMode, applied: false },
+};
+
+for (const [key, locs] of flagLocations) {
+  const name = Object.entries(FLAG_HASHES).find(([, v]) => v === key)?.[0] || 'unknown';
+  log(`Flag ${name} (${key}): ${locs.length} occurrence(s)`);
+  for (const loc of locs) {
+    log(`  ${loc.relFile} [${loc.node.start}]`);
+  }
+}
+
+log(`Platform label candidates: ${platformLabelCandidates.length}`);
+for (const c of platformLabelCandidates) {
+  log(`  ${c.relFile} [${c.fnNode.start}..${c.fnNode.end}]: returns ${[...c.strings].join(', ')}`);
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3: Apply sub-patches
+// ---------------------------------------------------------------------------
+// Track all patches grouped by file for correct offset management
+const allPatches = new Map(); // file → [{ start, end, replacement, description }]
+
+function addPatch(file, src, start, end, replacement, description) {
+  if (!allPatches.has(file)) {
+    allPatches.set(file, { src, patches: [] });
+  }
+  allPatches.get(file).patches.push({ start, end, replacement, description });
+}
+
+// --- Sub-patch A: Sessions-bridge init gate ---
+{
+  const locs = flagLocations.get(FLAG_HASHES.sessionsBridge);
+  if (locs.length > 0) {
+    for (const loc of locs) {
+      if (!loc.scope) {
+        log(`Sub-patch A: No enclosing scope for flag at ${loc.relFile}:${loc.node.start}`);
+        continue;
+      }
+
+      const boolInit = findNearbyBooleanInit(loc.ast, loc.src, loc.node, loc.scope);
+      if (boolInit && !boolInit.currentValue) {
+        addPatch(
+          loc.file, loc.src,
+          boolInit.start, boolInit.end,
+          '!0',
+          `Sub-patch A: Flip ${boolInit.raw} → !0 near sessionsBridge flag`,
+        );
+        subPatchResults.A.applied = true;
+        log(`Sub-patch A: Will flip ${boolInit.raw} → !0 at ${loc.relFile}:${boolInit.start}`);
+        break; // Only patch the first occurrence
+      }
+    }
+    if (!subPatchResults.A.applied) {
+      log('Sub-patch A: Found flag but no nearby boolean to flip.');
+    }
+  } else {
+    log('Sub-patch A: Flag 3572572142 not found.');
+  }
+}
+
+// --- Sub-patch B: Remote session control check ---
+{
+  const locs = flagLocations.get(FLAG_HASHES.remoteSessionControl);
+  if (locs.length > 0) {
+    for (const loc of locs) {
+      if (!loc.scope) {
+        log(`Sub-patch B: No enclosing scope for flag at ${loc.relFile}:${loc.node.start}`);
+        continue;
+      }
+
+      const cond = findConditionalNearFlag(loc.ast, loc.src, loc.node, loc.scope);
+      if (cond) {
+        addPatch(
+          loc.file, loc.src,
+          cond.start, cond.end,
+          '!1',
+          `Sub-patch B: Replace ${cond.raw} → !1 near remoteSessionControl flag`,
+        );
+        subPatchResults.B.applied = true;
+        log(`Sub-patch B: Will replace ${cond.raw} → !1 at ${loc.relFile}:${cond.start}`);
+        break;
+      }
+
+      // Fallback: try to find a nearby boolean init like sub-patch A
+      const boolInit = findNearbyBooleanInit(loc.ast, loc.src, loc.node, loc.scope);
+      if (boolInit && !boolInit.currentValue) {
+        addPatch(
+          loc.file, loc.src,
+          boolInit.start, boolInit.end,
+          '!0',
+          `Sub-patch B: Flip ${boolInit.raw} → !0 near remoteSessionControl flag`,
+        );
+        subPatchResults.B.applied = true;
+        log(`Sub-patch B: Will flip ${boolInit.raw} → !0 at ${loc.relFile}:${boolInit.start}`);
+        break;
+      }
+    }
+    if (!subPatchResults.B.applied) {
+      log('Sub-patch B: Found flag but no conditional/boolean to patch.');
+    }
+  } else {
+    log('Sub-patch B: Flag 2216414644 not found.');
+  }
+}
+
+// --- Sub-patch C: Platform label ---
+{
+  if (platformLabelCandidates.length > 0) {
+    // Pick the best candidate (shortest, most platform names)
+    const best = platformLabelCandidates[0];
+    const bodyNode = best.bodyNode;
+
+    if (bodyNode.type === 'BlockStatement') {
+      // Find the last return statement for the "unsupported" fallback
+      // and add a linux case before it.
+      // Strategy: find the conditional chain and add linux case.
+      // Simpler approach: prepend a linux check at the start of the function body.
+      const bodyStart = bodyNode.start; // points to '{'
+      const patch =
+        `{if(process.platform==="linux")return"Linux";` +
+        best.src.slice(bodyNode.start + 1, bodyNode.end);
+
+      addPatch(
+        best.file, best.src,
+        bodyNode.start, bodyNode.end,
+        patch,
+        `Sub-patch C: Add "linux" → "Linux" case to platform label function`,
+      );
+      subPatchResults.C.applied = true;
+      log(`Sub-patch C: Will add linux case to platform label at ${best.relFile}:${bodyNode.start}`);
+    } else {
+      // Concise arrow: expr → { if (linux) return "Linux"; return <expr>; }
+      const origExpr = best.src.slice(bodyNode.start, bodyNode.end);
+      const patch = `{if(process.platform==="linux")return"Linux";return ${origExpr}}`;
+
+      addPatch(
+        best.file, best.src,
+        bodyNode.start, bodyNode.end,
+        patch,
+        `Sub-patch C: Wrap concise arrow with linux case`,
+      );
+      subPatchResults.C.applied = true;
+      log(`Sub-patch C: Will wrap concise arrow at ${best.relFile}:${bodyNode.start}`);
+    }
+  } else {
+    log('Sub-patch C: No platform label function found.');
+  }
+}
+
+// --- Sub-patch D: hostLoopMode ---
+{
+  const locs = flagLocations.get(FLAG_HASHES.hostLoopMode);
+  if (locs.length > 0) {
+    for (const loc of locs) {
+      if (!loc.scope) {
+        log(`Sub-patch D: No enclosing scope for flag at ${loc.relFile}:${loc.node.start}`);
+        continue;
+      }
+
+      const boolInit = findNearbyBooleanInit(loc.ast, loc.src, loc.node, loc.scope);
+      if (boolInit && !boolInit.currentValue) {
+        addPatch(
+          loc.file, loc.src,
+          boolInit.start, boolInit.end,
+          '!0',
+          `Sub-patch D: Flip ${boolInit.raw} → !0 near hostLoopMode flag`,
+        );
+        subPatchResults.D.applied = true;
+        log(`Sub-patch D: Will flip ${boolInit.raw} → !0 at ${loc.relFile}:${boolInit.start}`);
+        break;
+      }
+    }
+    if (!subPatchResults.D.applied) {
+      log('Sub-patch D: Found flag but no nearby boolean to flip.');
+    }
+  } else {
+    log('Sub-patch D: Flag 1143815894 not found.');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Phase 4: Write patched files
+// ---------------------------------------------------------------------------
+let totalPatched = 0;
+
+for (const [file, { src, patches }] of allPatches) {
+  const relFile = relative(appDir, file);
+
+  // Sort patches by descending start offset to preserve earlier offsets
+  const sorted = patches.sort((a, b) => b.start - a.start);
+
+  let patched = src;
+  for (const p of sorted) {
+    log(`Applying: ${p.description}`);
+    patched = patched.slice(0, p.start) + p.replacement + patched.slice(p.end);
+    totalPatched++;
+  }
+
+  writeFileSync(file, patched, 'utf8');
+  log(`Wrote ${relFile} (${src.length} → ${patched.length} bytes)`);
+}
+
+// ---------------------------------------------------------------------------
+// Phase 5: Summary and exit
+// ---------------------------------------------------------------------------
+log('------------------------------------------------------------');
+log('Dispatch patch summary:');
+for (const [key, result] of Object.entries(subPatchResults)) {
+  const status = result.applied ? 'APPLIED' : 'NOT FOUND';
+  const hashStr = result.hash ? ` (${result.hash})` : '';
+  log(`  Sub-patch ${key} — ${result.name}${hashStr}: ${status}`);
+}
+log(`Total patches applied: ${totalPatched}`);
+log('------------------------------------------------------------');
+
+// Exit 1 only if ALL sub-patches failed (no useful patches at all)
+if (totalPatched === 0) {
+  log('ERROR: No Dispatch patches could be applied. The minified code may have changed structure.');
+  process.exit(1);
+}
+
+// Warn if some sub-patches didn't apply (non-fatal)
+const notApplied = Object.entries(subPatchResults).filter(([, r]) => !r.applied);
+if (notApplied.length > 0) {
+  log(`WARNING: ${notApplied.length} sub-patch(es) did not apply. Dispatch may be partially functional.`);
+}
+
+process.exit(0);

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -217,6 +217,7 @@ Installed-Size: ${INSTALLED_SIZE}
 Depends: bash, xdg-utils, libasound2 | libasound2t64, libatk-bridge2.0-0 | libatk-bridge2.0-0t64, libatk1.0-0 | libatk1.0-0t64, libcairo2, libcups2 | libcups2t64, libdbus-1-3, libdrm2, libexpat1, libgbm1, libglib2.0-0 | libglib2.0-0t64, libgtk-3-0 | libgtk-3-0t64, libnspr4, libnss3, libpango-1.0-0, libx11-6, libxcb1, libxcomposite1, libxdamage1, libxext6, libxfixes3, libxkbcommon0, libxrandr2
 Conflicts: liboss4-salsa-asound2
 Recommends: bubblewrap
+Suggests: cowork-svc-linux
 Section: net
 Priority: optional
 Homepage: https://github.com/stslex/claude-desktop-linux

--- a/scripts/build-pacman.sh
+++ b/scripts/build-pacman.sh
@@ -207,6 +207,7 @@ depend = gtk3
 depend = glib2
 depend = pango
 optdepend = bubblewrap: sandboxed Cowork sessions
+optdepend = cowork-svc-linux: Cowork/Dispatch socket daemon for Linux
 PKGINFO_EOF
 
 # ---------------------------------------------------------------------------

--- a/scripts/install-cowork-service.sh
+++ b/scripts/install-cowork-service.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# install-cowork-service.sh
+#
+# Downloads and installs the claude-cowork-service daemon from
+# https://github.com/patrickjaja/claude-cowork-service/releases
+#
+# The daemon speaks the same length-prefixed JSON-over-Unix-socket protocol
+# that Claude Desktop uses on Windows (named pipe) and macOS (vsock).  On
+# Linux it listens on a Unix domain socket and delegates to os/exec — no VM.
+#
+# Idempotent: re-running updates the binary and restarts the service.
+#
+# Requirements:
+#   - curl or wget
+#   - systemd (for user service management)
+#   - sha256sum (for binary verification)
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+log() {
+  echo "[$(date -u +"%Y-%m-%dT%H:%M:%SZ")] [install-cowork-service] $*"
+}
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+INSTALL_DIR="$HOME/.local/bin"
+BINARY_NAME="cowork-svc-linux"
+BINARY_PATH="$INSTALL_DIR/$BINARY_NAME"
+SYSTEMD_DIR="$HOME/.config/systemd/user"
+SERVICE_NAME="claude-cowork"
+SERVICE_FILE="$SYSTEMD_DIR/${SERVICE_NAME}.service"
+SOCKET_NAME="cowork-vm-service.sock"
+
+GITHUB_REPO="patrickjaja/claude-cowork-service"
+GITHUB_API="https://api.github.com/repos/$GITHUB_REPO/releases/latest"
+
+# ---------------------------------------------------------------------------
+# Dependency checks
+# ---------------------------------------------------------------------------
+check_dep() {
+  if ! command -v "$1" &>/dev/null; then
+    log "ERROR: '$1' not found. $2"
+    exit 1
+  fi
+}
+
+check_dep sha256sum "Install coreutils."
+
+DOWNLOADER=""
+if command -v curl &>/dev/null; then
+  DOWNLOADER="curl"
+elif command -v wget &>/dev/null; then
+  DOWNLOADER="wget"
+else
+  log "ERROR: Neither curl nor wget found. Install one of them."
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Detect architecture
+# ---------------------------------------------------------------------------
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64)  ARCH_SUFFIX="amd64" ;;
+  aarch64) ARCH_SUFFIX="arm64" ;;
+  *)
+    log "ERROR: Unsupported architecture: $ARCH"
+    exit 1
+    ;;
+esac
+
+log "Detected architecture: $ARCH ($ARCH_SUFFIX)"
+
+# ---------------------------------------------------------------------------
+# Fetch latest release info
+# ---------------------------------------------------------------------------
+log "Fetching latest release from $GITHUB_REPO..."
+
+RELEASE_JSON=""
+if [[ "$DOWNLOADER" == "curl" ]]; then
+  RELEASE_JSON="$(curl -fsSL "$GITHUB_API")" || {
+    log "ERROR: Failed to fetch release info from GitHub API."
+    exit 1
+  }
+else
+  RELEASE_JSON="$(wget -qO- "$GITHUB_API")" || {
+    log "ERROR: Failed to fetch release info from GitHub API."
+    exit 1
+  }
+fi
+
+# Extract the download URL for the correct architecture binary.
+# The release assets follow the pattern: cowork-svc-linux-<arch>
+# or claude-cowork-service-linux-<arch> or similar.
+DOWNLOAD_URL=""
+DOWNLOAD_URL="$(echo "$RELEASE_JSON" | \
+  node -e "
+    const data = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
+    const assets = data.assets || [];
+    const archPatterns = ['linux-${ARCH_SUFFIX}', 'linux_${ARCH_SUFFIX}', '${ARCH}'];
+    for (const asset of assets) {
+      const name = asset.name.toLowerCase();
+      if (name.includes('linux') && !name.endsWith('.sha256') && !name.endsWith('.md5')) {
+        for (const pat of archPatterns) {
+          if (name.includes(pat)) {
+            process.stdout.write(asset.browser_download_url);
+            process.exit(0);
+          }
+        }
+      }
+    }
+    // If no arch-specific match, try any linux binary
+    for (const asset of assets) {
+      const name = asset.name.toLowerCase();
+      if (name.includes('linux') && !name.endsWith('.sha256') && !name.endsWith('.md5') && !name.endsWith('.txt')) {
+        process.stdout.write(asset.browser_download_url);
+        process.exit(0);
+      }
+    }
+    process.exit(1);
+  " 2>/dev/null)" || true
+
+if [[ -z "$DOWNLOAD_URL" ]]; then
+  log "ERROR: Could not find a Linux $ARCH_SUFFIX binary in the latest release."
+  log "Available assets:"
+  echo "$RELEASE_JSON" | node -e "
+    const data = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
+    (data.assets || []).forEach(a => console.error('  - ' + a.name));
+  " 2>&1 || true
+  exit 1
+fi
+
+# Also look for a .sha256 file for the binary
+SHA256_URL=""
+SHA256_URL="$(echo "$RELEASE_JSON" | \
+  node -e "
+    const data = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
+    const assets = data.assets || [];
+    const binaryUrl = '${DOWNLOAD_URL}';
+    const binaryName = binaryUrl.split('/').pop();
+    for (const asset of assets) {
+      if (asset.name === binaryName + '.sha256' || asset.name === binaryName + '.sha256sum') {
+        process.stdout.write(asset.browser_download_url);
+        process.exit(0);
+      }
+    }
+    process.exit(1);
+  " 2>/dev/null)" || true
+
+RELEASE_TAG="$(echo "$RELEASE_JSON" | node -e "
+  const data = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
+  process.stdout.write(data.tag_name || 'unknown');
+" 2>/dev/null)" || RELEASE_TAG="unknown"
+
+log "Latest release: $RELEASE_TAG"
+log "Download URL: $DOWNLOAD_URL"
+
+# ---------------------------------------------------------------------------
+# Download binary
+# ---------------------------------------------------------------------------
+mkdir -p "$INSTALL_DIR"
+TMP_BINARY="$(mktemp)"
+trap 'rm -f "$TMP_BINARY"' EXIT
+
+log "Downloading $BINARY_NAME..."
+if [[ "$DOWNLOADER" == "curl" ]]; then
+  curl -fSL -o "$TMP_BINARY" "$DOWNLOAD_URL"
+else
+  wget -q -O "$TMP_BINARY" "$DOWNLOAD_URL"
+fi
+
+# ---------------------------------------------------------------------------
+# SHA256 verification
+# ---------------------------------------------------------------------------
+ACTUAL_SHA256="$(sha256sum "$TMP_BINARY" | awk '{print $1}')"
+
+if [[ -n "$SHA256_URL" ]]; then
+  log "Downloading SHA256 checksum..."
+  EXPECTED_SHA256=""
+  if [[ "$DOWNLOADER" == "curl" ]]; then
+    EXPECTED_SHA256="$(curl -fsSL "$SHA256_URL" | awk '{print $1}')"
+  else
+    EXPECTED_SHA256="$(wget -qO- "$SHA256_URL" | awk '{print $1}')"
+  fi
+
+  if [[ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]]; then
+    log "ERROR: SHA256 mismatch!"
+    log "  Expected: $EXPECTED_SHA256"
+    log "  Actual:   $ACTUAL_SHA256"
+    exit 1
+  fi
+  log "SHA256 verified: $ACTUAL_SHA256"
+else
+  log "WARNING: No .sha256 file found in release. Recording checksum for audit."
+  log "SHA256: $ACTUAL_SHA256"
+fi
+
+# Store checksum alongside binary
+echo "$ACTUAL_SHA256  $BINARY_NAME" > "$BINARY_PATH.sha256" 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+# Install binary
+# ---------------------------------------------------------------------------
+mv "$TMP_BINARY" "$BINARY_PATH"
+chmod 755 "$BINARY_PATH"
+trap - EXIT  # binary moved, no temp to clean
+log "Installed $BINARY_PATH"
+
+# ---------------------------------------------------------------------------
+# Create systemd user service
+# ---------------------------------------------------------------------------
+mkdir -p "$SYSTEMD_DIR"
+
+cat > "$SERVICE_FILE" <<'UNIT'
+[Unit]
+Description=Claude Cowork Service (Linux native backend)
+After=default.target
+
+[Service]
+Type=simple
+ExecStart=%h/.local/bin/cowork-svc-linux
+Restart=on-failure
+RestartSec=5
+Environment=XDG_RUNTIME_DIR=%t
+
+[Install]
+WantedBy=default.target
+UNIT
+
+log "Created systemd user service: $SERVICE_FILE"
+
+# ---------------------------------------------------------------------------
+# Enable and start the service
+# ---------------------------------------------------------------------------
+systemctl --user daemon-reload
+systemctl --user enable --now "$SERVICE_NAME"
+
+log "Service enabled and started."
+
+# ---------------------------------------------------------------------------
+# Verify socket
+# ---------------------------------------------------------------------------
+XDG_RUNTIME="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+SOCKET_PATH="$XDG_RUNTIME/$SOCKET_NAME"
+
+# Give the service a moment to create the socket
+for i in 1 2 3 4 5; do
+  if [[ -S "$SOCKET_PATH" ]]; then
+    break
+  fi
+  sleep 1
+done
+
+if [[ -S "$SOCKET_PATH" ]]; then
+  log "OK: Socket exists at $SOCKET_PATH"
+else
+  log "WARNING: Socket not found at $SOCKET_PATH after 5s."
+  log "Check service status: systemctl --user status $SERVICE_NAME"
+  log "Check service logs:   journalctl --user -u $SERVICE_NAME -f"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+log "------------------------------------------------------------"
+log "Installation complete."
+log "  Binary:  $BINARY_PATH"
+log "  Service: $SERVICE_FILE"
+log "  Socket:  $SOCKET_PATH"
+log "  Version: $RELEASE_TAG"
+log ""
+log "Useful commands:"
+log "  systemctl --user status $SERVICE_NAME"
+log "  journalctl --user -u $SERVICE_NAME -f"
+log "  systemctl --user restart $SERVICE_NAME"
+log "------------------------------------------------------------"

--- a/scripts/patch-cowork.sh
+++ b/scripts/patch-cowork.sh
@@ -308,6 +308,73 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Patch — Cowork socket transport: named pipe → Unix socket on Linux
+# ---------------------------------------------------------------------------
+log "Patching Cowork socket transport for Linux..."
+
+COWORK_SOCKET_LOG="$BUILD_DIR/patch-cowork-socket.log"
+
+set +e
+node "$PATCHES_DIR/patch-cowork-socket.mjs" "$APP_DIR" \
+  2>"$COWORK_SOCKET_LOG"
+COWORK_SOCKET_EXIT=$?
+set -e
+
+cat "$COWORK_SOCKET_LOG" >&2
+
+if [[ $COWORK_SOCKET_EXIT -ne 0 ]]; then
+  log "WARNING: patch-cowork-socket.mjs failed (exit $COWORK_SOCKET_EXIT) — Cowork socket transport may not work."
+else
+  log "Cowork socket transport patched."
+fi
+
+# ---------------------------------------------------------------------------
+# Patch — Dispatch feature flags (GrowthBook gates)
+# ---------------------------------------------------------------------------
+if [[ "${SKIP_DISPATCH_PATCH:-}" != "1" ]]; then
+  log "Patching Dispatch feature flags for Linux..."
+
+  DISPATCH_FLAGS_LOG="$BUILD_DIR/patch-dispatch-flags.log"
+
+  set +e
+  node "$PATCHES_DIR/patch-dispatch.mjs" "$APP_DIR" \
+    2>"$DISPATCH_FLAGS_LOG"
+  DISPATCH_FLAGS_EXIT=$?
+  set -e
+
+  cat "$DISPATCH_FLAGS_LOG" >&2
+
+  if [[ $DISPATCH_FLAGS_EXIT -ne 0 ]]; then
+    log "WARNING: patch-dispatch.mjs failed (exit $DISPATCH_FLAGS_EXIT) — Dispatch feature flags may not be enabled."
+  else
+    log "Dispatch feature flags patched."
+  fi
+else
+  log "Skipping Dispatch feature flag patches (SKIP_DISPATCH_PATCH=1)."
+fi
+
+# ---------------------------------------------------------------------------
+# Patch — ComputerUseTcc IPC stubs (AST injection)
+# ---------------------------------------------------------------------------
+log "Patching ComputerUseTcc IPC handlers..."
+
+TCC_PATCH_LOG="$BUILD_DIR/patch-tcc.log"
+
+set +e
+node "$PATCHES_DIR/patch-computer-use-tcc.mjs" "$APP_DIR" \
+  2>"$TCC_PATCH_LOG"
+TCC_PATCH_EXIT=$?
+set -e
+
+cat "$TCC_PATCH_LOG" >&2
+
+if [[ $TCC_PATCH_EXIT -ne 0 ]]; then
+  log "WARNING: patch-computer-use-tcc.mjs failed (exit $TCC_PATCH_EXIT) — ComputerUseTcc stubs may not be injected."
+else
+  log "ComputerUseTcc IPC handlers patched."
+fi
+
+# ---------------------------------------------------------------------------
 # Patch 4 — Find main entry point
 # ---------------------------------------------------------------------------
 log "Locating main entry point..."
@@ -500,6 +567,9 @@ log "  CCD platform patch  : linux-x64/linux-arm64 added to getHostPlatform + ge
 log "  VM download patch   : download_and_sdk_prepare returns early on Linux"
 log "  Bundle download gate: platform check bypassed for Linux"
 log "  Dispatch gate       : checked (shared with Cowork gate or patched separately)"
+log "  Cowork socket       : named pipe → Unix domain socket on Linux"
+log "  Dispatch flags      : GrowthBook feature flags force-enabled for Linux"
+log "  ComputerUseTcc      : IPC stubs injected into main bundle"
 log "  Patches injected    : $MAIN_ENTRY"
 log "    module-load-patch.js   (shared Module._load interceptor registry)"
 log "    shell-env-patch.js     (fix shell path worker not found on Linux)"


### PR DESCRIPTION
Add support for Cowork and Dispatch features on Linux by integrating
the claude-cowork-service daemon and adding AST-based patches for
socket transport, GrowthBook feature flags, and ComputerUseTcc stubs.

New files:
- scripts/install-cowork-service.sh: downloads and installs the Go
  daemon from patrickjaja/claude-cowork-service as a systemd user
  service
- patches/patch-cowork-socket.mjs: rewrites Windows named pipe path
  to Linux Unix domain socket
- patches/patch-dispatch.mjs: force-enables GrowthBook feature flags
  (sessions-bridge, remote session control, hostLoopMode, platform
  label) required for Dispatch
- patches/patch-computer-use-tcc.mjs: injects ComputerUseTcc IPC
  handler stubs directly into the main bundle

Updated:
- scripts/patch-cowork.sh: wires new patches into build pipeline
- Launcher scripts: warn if cowork service not running
- Packaging: add cowork-svc-linux as optional dependency
- Documentation: Socket IPC protocol, Dispatch on Linux architecture

https://claude.ai/code/session_01FkEAY5ZiBbAUFnjr5zLTUS