### PR TITLE
fix: restore VM status stubs + add dev/beta release channel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,30 +1,97 @@
 name: Build Claude Desktop Linux
 
 on:
+  push:
+    branches:
+      - main
+      - dev
+      - fix_cowork
+      - 'feat/**'
+      - 'fix/**'
+    tags:
+      - 'v*'
+  pull_request:
+    branches: ['dev', 'main']
   workflow_dispatch:
     inputs:
       version:
-        description: 'Claude Desktop version to build (blank = auto-detect)'
+        description: 'Override version (leave empty to auto-detect from DMG)'
         required: false
-      release:
-        description: 'Upload to GitHub Releases'
-        type: boolean
-        default: false
-  push:
-    branches: ['main', 'dev']
-  pull_request:
-    branches: ['dev', 'main']
+      channel:
+        description: 'Release channel'
+        type: choice
+        options:
+          - auto
+          - stable
+          - dev
+          - none
+        default: auto
 
 permissions: {}
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # Determine release channel
+  # ---------------------------------------------------------------------------
+  determine-channel:
+    name: Determine release channel
+    runs-on: ubuntu-latest
+    outputs:
+      channel: ${{ steps.channel.outputs.channel }}
+      version_suffix: ${{ steps.channel.outputs.version_suffix }}
+      release_name_prefix: ${{ steps.channel.outputs.release_name_prefix }}
+    steps:
+      - id: channel
+        run: |
+          # Manual dispatch override
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] && \
+             [[ "${{ inputs.channel }}" != "auto" ]] && \
+             [[ -n "${{ inputs.channel }}" ]]; then
+            CH="${{ inputs.channel }}"
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            CH="none"
+          elif [[ "${{ github.ref }}" == "refs/heads/main" ]] || \
+               [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            CH="stable"
+          elif [[ "${{ github.ref }}" == "refs/heads/dev" ]]; then
+            CH="dev"
+          else
+            CH="none"
+          fi
+
+          echo "channel=$CH" >> $GITHUB_OUTPUT
+
+          if [[ "$CH" == "stable" ]]; then
+            echo "version_suffix=" >> $GITHUB_OUTPUT
+            echo "release_name_prefix=" >> $GITHUB_OUTPUT
+          elif [[ "$CH" == "dev" ]]; then
+            DATE=$(date -u +%Y%m%d)
+            SHA="${GITHUB_SHA:0:7}"
+            echo "version_suffix=~dev.${DATE}.${SHA}" >> $GITHUB_OUTPUT
+            echo "release_name_prefix=[BETA] " >> $GITHUB_OUTPUT
+          else
+            # Feature branch — artifacts only, no release
+            SAFE_BRANCH="${GITHUB_REF_NAME//[^a-zA-Z0-9]/-}"
+            SHA="${GITHUB_SHA:0:7}"
+            echo "version_suffix=~${SAFE_BRANCH}.${SHA}" >> $GITHUB_OUTPUT
+            echo "release_name_prefix=" >> $GITHUB_OUTPUT
+          fi
+
+          echo "Channel: $CH"
+
+  # ---------------------------------------------------------------------------
+  # Build all packages
+  # ---------------------------------------------------------------------------
   build:
+    needs: determine-channel
     runs-on: ubuntu-latest
     permissions:
       contents: write
     env:
       BUILD_DIR:  /tmp/claude-build
       OUTPUT_DIR: ${{ github.workspace }}/output
+      CHANNEL: ${{ needs.determine-channel.outputs.channel }}
+      VERSION_SUFFIX: ${{ needs.determine-channel.outputs.version_suffix }}
 
     steps:
       - name: Checkout
@@ -64,6 +131,8 @@ jobs:
         run: |
           echo "version=$(cat "$BUILD_DIR/VERSION")"         >> "$GITHUB_OUTPUT"
           echo "electron=$(cat "$BUILD_DIR/ELECTRON_VERSION")" >> "$GITHUB_OUTPUT"
+          FULL="${{ env.VERSION_SUFFIX }}"
+          echo "full_version=$(cat "$BUILD_DIR/VERSION")${FULL}" >> "$GITHUB_OUTPUT"
 
       - name: Cache Electron binary
         uses: actions/cache@v4
@@ -92,10 +161,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           VERSION:  ${{ steps.ver.outputs.version }}
         run: |
-          # Count existing repacks for this exact Claude version.
           REPACK=0
-          if [[ "${{ github.ref }}" == "refs/heads/main" ]] || \
-             [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.release }}" == "true" ]]; then
+          if [[ "$CHANNEL" == "stable" ]]; then
             EXISTING="$(gh release list --repo "${{ github.repository }}" \
               --limit 200 --json tagName --jq '.[].tagName' 2>/dev/null || true)"
             while IFS= read -r tag; do
@@ -104,40 +171,39 @@ jobs:
                 (( N + 1 > REPACK )) && REPACK=$(( N + 1 ))
               fi
             done <<< "$EXISTING"
+          elif [[ "$CHANNEL" == "dev" ]]; then
+            # Dev builds always use repack 0 — the suffix distinguishes them
+            REPACK=0
           fi
           echo "num=${REPACK}" >> "$GITHUB_OUTPUT"
-          echo "tag=v${VERSION}-repack-${REPACK}" >> "$GITHUB_OUTPUT"
           echo "Computed repack number: ${REPACK}"
 
       - name: build-packages
         env:
-          KEEP_BUILD_DIR: '1'   # preserve BUILD_DIR so electron-cache can be saved
+          KEEP_BUILD_DIR: '1'
           REPACK_NUM: ${{ steps.repack.outputs.num }}
+          VERSION_SUFFIX: ${{ env.VERSION_SUFFIX }}
         run: bash scripts/build-packages.sh
 
       # -----------------------------------------------------------------------
-      # CI artifact (always — useful for dev/PR builds too)
+      # CI artifact (always — useful for dev/PR/feature builds)
       # -----------------------------------------------------------------------
       - name: Upload build artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: claude-desktop-${{ steps.ver.outputs.version }}
+          name: claude-desktop-${{ env.CHANNEL }}-${{ steps.ver.outputs.full_version }}
           path: output/
           if-no-files-found: warn
+          retention-days: ${{ env.CHANNEL == 'stable' && '90' || (env.CHANNEL == 'dev' && '30' || '7') }}
 
       # -----------------------------------------------------------------------
-      # GitHub Release
-      #   • push to main  → always release
-      #   • workflow_dispatch with release=true  → release
-      #   • push to dev / PR  → skip
+      # Rename assets to include repack suffix (stable + dev)
       # -----------------------------------------------------------------------
       - name: Rename assets to include repack suffix
-        if: >
-          github.ref == 'refs/heads/main' ||
-          (github.event_name == 'workflow_dispatch' && inputs.release == true)
+        if: env.CHANNEL == 'stable' || env.CHANNEL == 'dev'
         env:
-          VERSION: ${{ steps.ver.outputs.version }}
+          VERSION: ${{ steps.ver.outputs.full_version }}
           REPACK:  ${{ steps.repack.outputs.num }}
         run: |
           for ext in rpm deb pkg.tar.zst AppImage; do
@@ -148,15 +214,14 @@ jobs:
             sha256sum "$dst" | awk '{print $1}' > "${dst}.sha256"
             rm -f "${src}.sha256"
           done
-          # Create a pacman-compatible named copy (no "repack" — pacman requires
-          # {name}-{pkgver}-{pkgrel}-{arch}.pkg.tar.ext filename format).
+          # Create a pacman-compatible named copy
           REPACK_PKG="output/claude-desktop-${VERSION}-repack-${REPACK}-x86_64.pkg.tar.zst"
           PACMAN_PKG="output/claude-desktop-${VERSION}-${REPACK}-x86_64.pkg.tar.zst"
           if [[ -f "$REPACK_PKG" ]]; then
             cp "$REPACK_PKG" "$PACMAN_PKG"
             cp "${REPACK_PKG}.sha256" "${PACMAN_PKG}.sha256"
           fi
-          # Rename the Nix tarball (different naming convention).
+          # Rename the Nix tarball
           NIX_SRC="output/claude-desktop-${VERSION}-x86_64-nix.tar.gz"
           NIX_DST="output/claude-desktop-${VERSION}-repack-${REPACK}-x86_64-nix.tar.gz"
           if [[ -f "$NIX_SRC" ]]; then
@@ -164,8 +229,7 @@ jobs:
             sha256sum "$NIX_DST" | awk '{print $1}' > "${NIX_DST}.sha256"
             rm -f "${NIX_SRC}.sha256"
           fi
-          # Remove the stale zsync (it has the wrong embedded filename) and
-          # regenerate it from the renamed AppImage so the internal URL matches.
+          # Regenerate zsync from renamed AppImage
           rm -f "output/claude-desktop-${VERSION}-x86_64.AppImage.zsync"
           APPIMAGE="output/claude-desktop-${VERSION}-repack-${REPACK}-x86_64.AppImage"
           ZSYNC="output/claude-desktop-${VERSION}-repack-${REPACK}-x86_64.AppImage.zsync"
@@ -175,11 +239,9 @@ jobs:
 
       - name: Compute checksums for release notes
         id: sums
-        if: >
-          github.ref == 'refs/heads/main' ||
-          (github.event_name == 'workflow_dispatch' && inputs.release == true)
+        if: env.CHANNEL == 'stable' || env.CHANNEL == 'dev'
         env:
-          VERSION: ${{ steps.ver.outputs.version }}
+          VERSION: ${{ steps.ver.outputs.full_version }}
           REPACK:  ${{ steps.repack.outputs.num }}
         run: |
           BASE="output/claude-desktop-${VERSION}-repack-${REPACK}-x86_64"
@@ -194,22 +256,23 @@ jobs:
           echo "nix=${NIX_SHA}"       >> "$GITHUB_OUTPUT"
           echo "appimage=${AI_SHA}"   >> "$GITHUB_OUTPUT"
 
-      - name: Create GitHub Release
-        if: >
-          github.ref == 'refs/heads/main' ||
-          (github.event_name == 'workflow_dispatch' && inputs.release == true)
+      # -----------------------------------------------------------------------
+      # Stable GitHub Release
+      # -----------------------------------------------------------------------
+      - name: Create stable GitHub Release
+        if: env.CHANNEL == 'stable'
         env:
           GH_TOKEN:  ${{ github.token }}
           VERSION:   ${{ steps.ver.outputs.version }}
           ELECTRON:  ${{ steps.ver.outputs.electron }}
           REPACK:    ${{ steps.repack.outputs.num }}
-          TAG:       ${{ steps.repack.outputs.tag }}
           RPM_SHA:   ${{ steps.sums.outputs.rpm }}
           DEB_SHA:   ${{ steps.sums.outputs.deb }}
           PKG_SHA:   ${{ steps.sums.outputs.pacman }}
           NIX_SHA:   ${{ steps.sums.outputs.nix }}
           AI_SHA:    ${{ steps.sums.outputs.appimage }}
         run: |
+          TAG="v${VERSION}-repack-${REPACK}"
           BASE="output/claude-desktop-${VERSION}-repack-${REPACK}-x86_64"
           NOTES=$(cat <<'NOTES_EOF'
           ## Claude Desktop Linux v${VERSION} (repack-${REPACK})
@@ -230,10 +293,8 @@ jobs:
           > Claude Desktop is Anthropic's proprietary software.
           NOTES_EOF
           )
-          # Expand only our known vars (prevents leaking runner env into notes).
           NOTES="$(echo "$NOTES" | envsubst '${VERSION} ${REPACK} ${RPM_SHA} ${DEB_SHA} ${PKG_SHA} ${NIX_SHA} ${AI_SHA} ${ELECTRON}')"
 
-          # Build asset list — only include files that actually exist.
           ASSETS=()
           PACMAN_BASE="output/claude-desktop-${VERSION}-${REPACK}-x86_64"
           for f in "${BASE}.rpm" "${BASE}.rpm.sha256" \
@@ -258,46 +319,136 @@ jobs:
             "${ASSETS[@]}"
 
       # -----------------------------------------------------------------------
-      # Prepare GitHub Pages content (all package repository metadata)
-      #   Metadata and binaries live on Pages; RPM binaries are in Releases.
-      #   Deployed via actions/deploy-pages for reliable GitHub Pages updates.
+      # Dev / Beta GitHub Release (prerelease)
+      # -----------------------------------------------------------------------
+      - name: Create dev GitHub Release
+        if: env.CHANNEL == 'dev'
+        env:
+          GH_TOKEN:    ${{ github.token }}
+          VERSION:     ${{ steps.ver.outputs.version }}
+          FULL_VERSION: ${{ steps.ver.outputs.full_version }}
+          ELECTRON:    ${{ steps.ver.outputs.electron }}
+          REPACK:      ${{ steps.repack.outputs.num }}
+          RPM_SHA:     ${{ steps.sums.outputs.rpm }}
+          DEB_SHA:     ${{ steps.sums.outputs.deb }}
+          PKG_SHA:     ${{ steps.sums.outputs.pacman }}
+          NIX_SHA:     ${{ steps.sums.outputs.nix }}
+          AI_SHA:      ${{ steps.sums.outputs.appimage }}
+        run: |
+          BUILD_DATE="$(date -u +%Y%m%d)"
+          SHORT_SHA="${GITHUB_SHA:0:7}"
+          TAG="v${VERSION}-dev.${BUILD_DATE}.${SHORT_SHA}"
+          BASE="output/claude-desktop-${FULL_VERSION}-repack-${REPACK}-x86_64"
+          NOTES=$(cat <<NOTES_EOF
+          ## [BETA] Claude Desktop Linux v${VERSION} dev.${BUILD_DATE}.${SHORT_SHA}
+
+          > **This is an untested development build from the \`dev\` branch.**
+          >
+          > - Experimental: may contain bugs, broken features, or fail to launch
+          > - Not tested: has not gone through stable release validation
+          > - Opt-in only: do NOT install unless you are actively testing
+          > - Rollback: if this build breaks your install, downgrade to stable:
+          >   \`sudo dnf downgrade claude-desktop\`
+
+          ### What's in this build
+
+          Branch: \`dev\`
+          Commit: ${GITHUB_SHA}
+          Build date: $(date -u +"%Y-%m-%d %H:%M UTC")
+
+          | Asset | SHA256 |
+          |---|---|
+          | RPM | \`${RPM_SHA}\` |
+          | DEB | \`${DEB_SHA}\` |
+          | Pacman | \`${PKG_SHA}\` |
+          | Nix | \`${NIX_SHA}\` |
+          | AppImage | \`${AI_SHA}\` |
+
+          **Electron:** ${ELECTRON}
+
+          **If you are not actively testing, use the [stable release](https://github.com/${{ github.repository }}/releases/latest) instead.**
+          NOTES_EOF
+          )
+
+          ASSETS=()
+          PACMAN_BASE="output/claude-desktop-${FULL_VERSION}-${REPACK}-x86_64"
+          for f in "${BASE}.rpm" "${BASE}.rpm.sha256" \
+                   "${BASE}.deb" "${BASE}.deb.sha256" \
+                   "${BASE}.pkg.tar.zst" "${BASE}.pkg.tar.zst.sha256" \
+                   "${PACMAN_BASE}.pkg.tar.zst" "${PACMAN_BASE}.pkg.tar.zst.sha256" \
+                   "${BASE}-nix.tar.gz" "${BASE}-nix.tar.gz.sha256" \
+                   "${BASE}.AppImage" "${BASE}.AppImage.sha256" \
+                   "${BASE}.AppImage.zsync"; do
+            [[ -f "$f" ]] && ASSETS+=("$f")
+          done
+
+          if [[ ${#ASSETS[@]} -eq 0 ]]; then
+            echo "ERROR: no release assets found — nothing to upload." >&2
+            exit 1
+          fi
+
+          gh release create "${TAG}" \
+            --repo "${{ github.repository }}" \
+            --title "[BETA] Claude Desktop Linux v${VERSION} dev.${BUILD_DATE}.${SHORT_SHA}" \
+            --prerelease \
+            --notes "$NOTES" \
+            "${ASSETS[@]}"
+
+      # -----------------------------------------------------------------------
+      # Prepare GitHub Pages content (repository metadata)
+      #   Stable → /stable/ directory    Dev → /dev/ directory
       # -----------------------------------------------------------------------
       - name: Build repository metadata for GitHub Pages
-        if: >
-          github.ref == 'refs/heads/main' ||
-          (github.event_name == 'workflow_dispatch' && inputs.release == true)
+        if: env.CHANNEL == 'stable' || env.CHANNEL == 'dev'
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.ver.outputs.version }}
+          FULL_VERSION: ${{ steps.ver.outputs.full_version }}
           REPACK:  ${{ steps.repack.outputs.num }}
-          TAG:     ${{ steps.repack.outputs.tag }}
         run: |
           REPO_USER="${GITHUB_REPOSITORY%%/*}"
           REPO_NAME="${GITHUB_REPOSITORY##*/}"
           PAGES_URL="https://${REPO_USER}.github.io/${REPO_NAME}"
-          DOWNLOAD_PREFIX="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}"
           PAGES_DIR="${GITHUB_WORKSPACE}/pages"
           mkdir -p "$PAGES_DIR"
 
-          # Disable Jekyll so GitHub Pages serves files as-is.
           touch "$PAGES_DIR/.nojekyll"
 
+          # Determine channel-specific paths and tag
+          if [[ "$CHANNEL" == "stable" ]]; then
+            CH_DIR="stable"
+            TAG="v${VERSION}-repack-${REPACK}"
+            PKG_VERSION="${VERSION}"
+            REPO_NAME_SUFFIX=""
+            REPO_DISPLAY="Claude Desktop Linux (Stable)"
+          else
+            BUILD_DATE="$(date -u +%Y%m%d)"
+            SHORT_SHA="${GITHUB_SHA:0:7}"
+            CH_DIR="dev"
+            TAG="v${VERSION}-dev.${BUILD_DATE}.${SHORT_SHA}"
+            PKG_VERSION="${FULL_VERSION}"
+            REPO_NAME_SUFFIX="-dev"
+            REPO_DISPLAY="Claude Desktop Linux (Beta / Development)"
+          fi
+          DOWNLOAD_PREFIX="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}"
+
           # -------------------------------------------------------------------
-          # DNF / RPM repository
+          # DNF / RPM repository → /stable/rpm/ or /dev/rpm/
           # -------------------------------------------------------------------
-          STAGING_DIR="$(mktemp -d)"
-          RPM_SRC="output/claude-desktop-${VERSION}-repack-${REPACK}-x86_64.rpm"
+          RPM_SRC="output/claude-desktop-${PKG_VERSION}-repack-${REPACK}-x86_64.rpm"
           if [[ -f "$RPM_SRC" ]]; then
+            STAGING_DIR="$(mktemp -d)"
             cp "$RPM_SRC" "$STAGING_DIR/"
             createrepo_c --location-prefix "$DOWNLOAD_PREFIX" "$STAGING_DIR"
 
-            mkdir -p "$PAGES_DIR/rpm"
-            cp -a "$STAGING_DIR/repodata" "$PAGES_DIR/rpm/"
+            mkdir -p "$PAGES_DIR/${CH_DIR}/rpm"
+            cp -a "$STAGING_DIR/repodata" "$PAGES_DIR/${CH_DIR}/rpm/"
+            rm -rf "$STAGING_DIR"
 
-            cat > "$PAGES_DIR/claude-desktop.repo" <<REPO_EOF
-          [claude-desktop]
-          name=Claude Desktop Linux (unofficial)
-          baseurl=${PAGES_URL}/rpm/
+            cat > "$PAGES_DIR/claude-desktop${REPO_NAME_SUFFIX}.repo" <<REPO_EOF
+          [claude-desktop${REPO_NAME_SUFFIX}]
+          name=${REPO_DISPLAY}
+          baseurl=${PAGES_URL}/${CH_DIR}/rpm/
           enabled=1
           gpgcheck=0
           metadata_expire=1h
@@ -305,27 +456,21 @@ jobs:
           else
             echo "No RPM found — skipping DNF repo metadata."
           fi
-          rm -rf "$STAGING_DIR"
 
           # -------------------------------------------------------------------
           # Pacman / Arch Linux repository
-          #   Repo database and package are served from GitHub Releases to
-          #   avoid large-file corruption through the Pages artifact pipeline.
-          #   Config files and install helper remain on Pages.
           # -------------------------------------------------------------------
-          PKG_SRC="output/claude-desktop-${VERSION}-repack-${REPACK}-x86_64.pkg.tar.zst"
+          PKG_SRC="output/claude-desktop-${PKG_VERSION}-repack-${REPACK}-x86_64.pkg.tar.zst"
           if [[ -f "$PKG_SRC" ]]; then
             PACMAN_DIR="$(mktemp -d)"
+            PACMAN_PKG="claude-desktop-${PKG_VERSION}-${REPACK}-x86_64.pkg.tar.zst"
 
-            # Pacman requires filenames to match {name}-{pkgver}-{pkgrel}-{arch}.pkg.tar.ext.
-            # The release asset uses "-repack-N"; create a pacman-compatible copy.
-            PACMAN_PKG="claude-desktop-${VERSION}-${REPACK}-x86_64.pkg.tar.zst"
+            if [[ "$CHANNEL" == "stable" ]]; then
+              PACMAN_SERVER="https://github.com/${GITHUB_REPOSITORY}/releases/latest/download"
+            else
+              PACMAN_SERVER="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}"
+            fi
 
-            # Serve from GitHub Releases — the /releases/latest/download/ URL
-            # always redirects to the most recent release's assets.
-            PACMAN_SERVER="https://github.com/${GITHUB_REPOSITORY}/releases/latest/download"
-
-            # Build the repo database manually (repo-add is Arch-specific).
             PKG_SHA256="$(sha256sum "$PKG_SRC" | awk '{print $1}')"
             PKG_SIZE="$(stat -c%s "$PKG_SRC")"
             CSIZE="$PKG_SIZE"
@@ -334,7 +479,7 @@ jobs:
             ISIZE="$(zstd -d -c "$PKG_SRC" 2>/dev/null | bsdtar -xf - -O .PKGINFO 2>/dev/null | grep '^size = ' | awk '{print $3}')"
             ISIZE="${ISIZE:-0}"
 
-            ENTRY_DIR="$DB_STAGING/claude-desktop-${VERSION}-${REPACK}"
+            ENTRY_DIR="$DB_STAGING/claude-desktop-${PKG_VERSION}-${REPACK}"
             mkdir -p "$ENTRY_DIR"
             cat > "$ENTRY_DIR/desc" <<DESC_EOF
           %FILENAME%
@@ -344,7 +489,7 @@ jobs:
           claude-desktop
 
           %VERSION%
-          ${VERSION}-${REPACK}
+          ${PKG_VERSION}-${REPACK}
 
           %DESC%
           Claude Desktop for Linux (unofficial rebuild)
@@ -398,13 +543,11 @@ jobs:
           bubblewrap: sandboxed Cowork sessions
           DESC_EOF
 
-            tar -czf "$PACMAN_DIR/claude-desktop.db.tar.gz" -C "$DB_STAGING" "claude-desktop-${VERSION}-${REPACK}"
+            tar -czf "$PACMAN_DIR/claude-desktop.db.tar.gz" -C "$DB_STAGING" "claude-desktop-${PKG_VERSION}-${REPACK}"
             rm -rf "$DB_STAGING"
 
             cp "$PACMAN_DIR/claude-desktop.db.tar.gz" "$PACMAN_DIR/claude-desktop.db"
 
-            # Upload the pacman-compatible package and database to the
-            # existing GitHub Release so everything lives at one URL.
             cp "$PKG_SRC" "$PACMAN_DIR/${PACMAN_PKG}"
             gh release upload "${TAG}" \
               "$PACMAN_DIR/${PACMAN_PKG}" \
@@ -413,20 +556,16 @@ jobs:
               --repo "${GITHUB_REPOSITORY}" --clobber
             rm -rf "$PACMAN_DIR"
 
-            # Config files stay on Pages (small, no corruption risk).
-            cat > "$PAGES_DIR/claude-desktop-pacman.conf" <<PACMAN_EOF
-          [claude-desktop]
+            cat > "$PAGES_DIR/claude-desktop${REPO_NAME_SUFFIX}-pacman.conf" <<PACMAN_EOF
+          [claude-desktop${REPO_NAME_SUFFIX}]
           SigLevel = Optional TrustAll
           Server = ${PACMAN_SERVER}
           PACMAN_EOF
 
-            cat > "$PAGES_DIR/install-pacman-repo.sh" <<INSTALL_PACMAN_EOF
+            # Only write the install helper for stable channel
+            if [[ "$CHANNEL" == "stable" ]]; then
+              cat > "$PAGES_DIR/install-pacman-repo.sh" <<INSTALL_PACMAN_EOF
           #!/bin/sh
-          # Add the Claude Desktop repository to pacman.
-          # Usage:
-          #   curl -fsSLo install-pacman-repo.sh ${PAGES_URL}/install-pacman-repo.sh
-          #   less install-pacman-repo.sh  # inspect before running
-          #   sudo sh install-pacman-repo.sh
           set -e
           if ! grep -q '\[claude-desktop\]' /etc/pacman.conf 2>/dev/null; then
             printf '\n[claude-desktop]\nSigLevel = Optional TrustAll\nServer = ${PACMAN_SERVER}\n' >> /etc/pacman.conf
@@ -436,26 +575,27 @@ jobs:
             echo "claude-desktop repository already configured."
           fi
           INSTALL_PACMAN_EOF
+            fi
           else
             echo "No pacman package found — skipping Pacman repo metadata."
           fi
 
           # -------------------------------------------------------------------
           # NixOS — version metadata JSON
-          #   NixOS users use the flake.nix directly; we publish latest info.
           # -------------------------------------------------------------------
-          NIX_SRC="output/claude-desktop-${VERSION}-repack-${REPACK}-x86_64-nix.tar.gz"
+          NIX_SRC="output/claude-desktop-${PKG_VERSION}-repack-${REPACK}-x86_64-nix.tar.gz"
           if [[ -f "$NIX_SRC" ]]; then
-            NIX_DIR="$PAGES_DIR/nix"
+            NIX_DIR="$PAGES_DIR/${CH_DIR}/nix"
             mkdir -p "$NIX_DIR"
             NIX_SHA256="$(sha256sum "$NIX_SRC" | awk '{print $1}')"
 
             cat > "$NIX_DIR/latest.json" <<NIX_EOF
           {
-            "version": "${VERSION}",
+            "version": "${PKG_VERSION}",
             "repack": ${REPACK},
             "tag": "${TAG}",
-            "url": "${DOWNLOAD_PREFIX}/claude-desktop-${VERSION}-repack-${REPACK}-x86_64-nix.tar.gz",
+            "channel": "${CHANNEL}",
+            "url": "${DOWNLOAD_PREFIX}/claude-desktop-${PKG_VERSION}-repack-${REPACK}-x86_64-nix.tar.gz",
             "sha256": "${NIX_SHA256}"
           }
           NIX_EOF
@@ -464,13 +604,11 @@ jobs:
           fi
 
           # -------------------------------------------------------------------
-          # APT / DEB repository
-          #   Uses apt-ftparchive to generate Packages metadata.
-          #   The .deb lives on Pages so APT can fetch it via relative Filename.
+          # APT / DEB repository → /stable/deb/ or /dev/deb/
           # -------------------------------------------------------------------
-          DEB_SRC="output/claude-desktop-${VERSION}-repack-${REPACK}-x86_64.deb"
+          DEB_SRC="output/claude-desktop-${PKG_VERSION}-repack-${REPACK}-x86_64.deb"
           if [[ -f "$DEB_SRC" ]]; then
-            APT_DIR="$PAGES_DIR/deb"
+            APT_DIR="$PAGES_DIR/${CH_DIR}/deb"
             mkdir -p "$APT_DIR"
 
             cp "$DEB_SRC" "$APT_DIR/"
@@ -482,24 +620,35 @@ jobs:
 
             cd "$GITHUB_WORKSPACE"
 
-            # DEB822 format .sources file.
-            cat > "$PAGES_DIR/claude-desktop.sources" <<SOURCES_EOF
+            # DEB822 format .sources file
+            cat > "$PAGES_DIR/claude-desktop${REPO_NAME_SUFFIX}.sources" <<SOURCES_EOF
           Types: deb
-          URIs: ${PAGES_URL}/deb
+          URIs: ${PAGES_URL}/${CH_DIR}/deb
           Suites: ./
           Trusted: yes
           SOURCES_EOF
 
-            # Traditional .list one-liner.
-            echo "deb [trusted=yes] ${PAGES_URL}/deb ./" > "$PAGES_DIR/claude-desktop.list"
+            # Traditional .list one-liner
+            echo "deb [trusted=yes] ${PAGES_URL}/${CH_DIR}/deb ./" > "$PAGES_DIR/claude-desktop${REPO_NAME_SUFFIX}.list"
           else
             echo "No .deb found — skipping APT repo metadata."
           fi
 
+          # -------------------------------------------------------------------
+          # Backward-compatible aliases for stable channel
+          #   Users who already have claude-desktop.repo pointing to /rpm/
+          #   should still work. Symlink /rpm/ → /stable/rpm/ etc.
+          # -------------------------------------------------------------------
+          if [[ "$CHANNEL" == "stable" ]]; then
+            # Create redirect aliases so old /rpm/ URLs still work
+            if [[ -d "$PAGES_DIR/stable/rpm" ]]; then
+              mkdir -p "$PAGES_DIR/rpm"
+              cp -a "$PAGES_DIR/stable/rpm/repodata" "$PAGES_DIR/rpm/" 2>/dev/null || true
+            fi
+          fi
+
       - name: Upload Pages artifact
-        if: >
-          github.ref == 'refs/heads/main' ||
-          (github.event_name == 'workflow_dispatch' && inputs.release == true)
+        if: env.CHANNEL == 'stable' || env.CHANNEL == 'dev'
         uses: actions/upload-pages-artifact@v3
         with:
           path: pages/
@@ -508,10 +657,10 @@ jobs:
   # Deploy repository metadata to GitHub Pages
   # ---------------------------------------------------------------------------
   deploy-pages:
-    needs: build
+    needs: [determine-channel, build]
     if: >
-      github.ref == 'refs/heads/main' ||
-      (github.event_name == 'workflow_dispatch' && inputs.release == true)
+      needs.determine-channel.outputs.channel == 'stable' ||
+      needs.determine-channel.outputs.channel == 'dev'
     runs-on: ubuntu-latest
     permissions:
       pages: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,6 @@ on:
     branches: ['dev', 'main']
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Override version (leave empty to auto-detect from DMG)'
-        required: false
       channel:
         description: 'Release channel'
         type: choice
@@ -36,7 +33,8 @@ jobs:
     outputs:
       channel: ${{ steps.channel.outputs.channel }}
       version_suffix: ${{ steps.channel.outputs.version_suffix }}
-      release_name_prefix: ${{ steps.channel.outputs.release_name_prefix }}
+      dev_build_date: ${{ steps.channel.outputs.dev_build_date }}
+      dev_short_sha: ${{ steps.channel.outputs.dev_short_sha }}
     steps:
       - id: channel
         run: |
@@ -60,16 +58,15 @@ jobs:
 
           if [[ "$CH" == "stable" ]]; then
             echo "version_suffix=" >> $GITHUB_OUTPUT
-            echo "release_name_prefix=" >> $GITHUB_OUTPUT
           elif [[ "$CH" == "dev" ]]; then
             DATE=$(date -u +%Y%m%d)
             SHA="${GITHUB_SHA:0:7}"
             echo "version_suffix=~dev.${DATE}.${SHA}" >> $GITHUB_OUTPUT
-            echo "release_name_prefix=[BETA] " >> $GITHUB_OUTPUT
+            echo "dev_build_date=${DATE}" >> $GITHUB_OUTPUT
+            echo "dev_short_sha=${SHA}" >> $GITHUB_OUTPUT
           else
             # PR — artifacts only, no release
             echo "version_suffix=" >> $GITHUB_OUTPUT
-            echo "release_name_prefix=" >> $GITHUB_OUTPUT
           fi
 
           echo "Channel: $CH"
@@ -87,6 +84,8 @@ jobs:
       OUTPUT_DIR: ${{ github.workspace }}/output
       CHANNEL: ${{ needs.determine-channel.outputs.channel }}
       VERSION_SUFFIX: ${{ needs.determine-channel.outputs.version_suffix }}
+      DEV_BUILD_DATE: ${{ needs.determine-channel.outputs.dev_build_date }}
+      DEV_SHORT_SHA: ${{ needs.determine-channel.outputs.dev_short_sha }}
 
     steps:
       - name: Checkout
@@ -330,12 +329,10 @@ jobs:
           NIX_SHA:     ${{ steps.sums.outputs.nix }}
           AI_SHA:      ${{ steps.sums.outputs.appimage }}
         run: |
-          BUILD_DATE="$(date -u +%Y%m%d)"
-          SHORT_SHA="${GITHUB_SHA:0:7}"
-          TAG="v${VERSION}-dev.${BUILD_DATE}.${SHORT_SHA}"
+          TAG="v${VERSION}-dev.${DEV_BUILD_DATE}.${DEV_SHORT_SHA}"
           BASE="output/claude-desktop-${FULL_VERSION}-repack-${REPACK}-x86_64"
           NOTES=$(cat <<NOTES_EOF
-          ## [BETA] Claude Desktop Linux v${VERSION} dev.${BUILD_DATE}.${SHORT_SHA}
+          ## [BETA] Claude Desktop Linux v${VERSION} dev.${DEV_BUILD_DATE}.${DEV_SHORT_SHA}
 
           > **This is an untested development build from the \`dev\` branch.**
           >
@@ -349,7 +346,6 @@ jobs:
 
           Branch: \`dev\`
           Commit: ${GITHUB_SHA}
-          Build date: $(date -u +"%Y-%m-%d %H:%M UTC")
 
           | Asset | SHA256 |
           |---|---|
@@ -384,7 +380,7 @@ jobs:
 
           gh release create "${TAG}" \
             --repo "${{ github.repository }}" \
-            --title "[BETA] Claude Desktop Linux v${VERSION} dev.${BUILD_DATE}.${SHORT_SHA}" \
+            --title "[BETA] Claude Desktop Linux v${VERSION} dev.${DEV_BUILD_DATE}.${DEV_SHORT_SHA}" \
             --prerelease \
             --notes "$NOTES" \
             "${ASSETS[@]}"
@@ -417,10 +413,8 @@ jobs:
             REPO_NAME_SUFFIX=""
             REPO_DISPLAY="Claude Desktop Linux (Stable)"
           else
-            BUILD_DATE="$(date -u +%Y%m%d)"
-            SHORT_SHA="${GITHUB_SHA:0:7}"
             CH_DIR="dev"
-            TAG="v${VERSION}-dev.${BUILD_DATE}.${SHORT_SHA}"
+            TAG="v${VERSION}-dev.${DEV_BUILD_DATE}.${DEV_SHORT_SHA}"
             PKG_VERSION="${FULL_VERSION}"
             REPO_NAME_SUFFIX="-dev"
             REPO_DISPLAY="Claude Desktop Linux (Beta / Development)"
@@ -631,14 +625,21 @@ jobs:
 
           # -------------------------------------------------------------------
           # Backward-compatible aliases for stable channel
-          #   Users who already have claude-desktop.repo pointing to /rpm/
-          #   should still work. Symlink /rpm/ → /stable/rpm/ etc.
+          #   Users who already have repos pointing to /rpm/, /deb/, /nix/
+          #   (without /stable/ prefix) should still work.
           # -------------------------------------------------------------------
           if [[ "$CHANNEL" == "stable" ]]; then
-            # Create redirect aliases so old /rpm/ URLs still work
             if [[ -d "$PAGES_DIR/stable/rpm" ]]; then
               mkdir -p "$PAGES_DIR/rpm"
               cp -a "$PAGES_DIR/stable/rpm/repodata" "$PAGES_DIR/rpm/" 2>/dev/null || true
+            fi
+            if [[ -d "$PAGES_DIR/stable/deb" ]]; then
+              mkdir -p "$PAGES_DIR/deb"
+              cp -a "$PAGES_DIR/stable/deb/." "$PAGES_DIR/deb/" 2>/dev/null || true
+            fi
+            if [[ -d "$PAGES_DIR/stable/nix" ]]; then
+              mkdir -p "$PAGES_DIR/nix"
+              cp -a "$PAGES_DIR/stable/nix/." "$PAGES_DIR/nix/" 2>/dev/null || true
             fi
           fi
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - main
       - dev
-      - fix_cowork
-      - 'feat/**'
-      - 'fix/**'
     tags:
       - 'v*'
   pull_request:
@@ -70,10 +67,8 @@ jobs:
             echo "version_suffix=~dev.${DATE}.${SHA}" >> $GITHUB_OUTPUT
             echo "release_name_prefix=[BETA] " >> $GITHUB_OUTPUT
           else
-            # Feature branch — artifacts only, no release
-            SAFE_BRANCH="${GITHUB_REF_NAME//[^a-zA-Z0-9]/-}"
-            SHA="${GITHUB_SHA:0:7}"
-            echo "version_suffix=~${SAFE_BRANCH}.${SHA}" >> $GITHUB_OUTPUT
+            # PR — artifacts only, no release
+            echo "version_suffix=" >> $GITHUB_OUTPUT
             echo "release_name_prefix=" >> $GITHUB_OUTPUT
           fi
 

--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -84,6 +84,7 @@ entirely and run the Claude Code binary directly on the host.
 | `DISPATCH_POLL_INTERVAL_MS` | `30000` | Dispatch foreground polling interval (ms) |
 | `SKIP_DISPATCH_POLL` | `` | Set to `1` to disable Dispatch polling |
 | `ENABLE_EXPERIMENTAL_PATCHES` | `` | Set to `1` to run cowork-socket, dispatch, and computer-use-tcc AST patches (off by default — they corrupt the JS bundle) |
+| `VERSION_SUFFIX` | `` | Appended to version in filenames and package metadata (e.g. `~dev.20260404.abc1234`); set automatically by CI |
 
 ## Build Dependencies
 
@@ -337,6 +338,31 @@ warn if the service is not running but do not block app launch.
 - Run with `--no-sandbox` because the AppImage FUSE mount prevents the
   `chrome-sandbox` setuid bit from taking effect.
 - Output filename: `claude-desktop-<version>-x86_64.AppImage`
+
+## Release Channels
+
+This project has two release channels that share the same codebase:
+
+| Channel | Branch | GitHub Release | gh-pages path | .repo file |
+|---------|--------|----------------|---------------|------------|
+| Stable  | `main` | Regular (Latest) | `/stable/` | `claude-desktop.repo` |
+| Dev     | `dev`  | Pre-release | `/dev/` | `claude-desktop-dev.repo` |
+
+Feature branches (`fix_cowork`, `feat/**`, `fix/**`) produce workflow artifacts
+only, never published. Download them from the Actions tab for local testing.
+
+The channel is determined automatically by `.github/workflows/build.yml` via
+the `determine-channel` job. Manual dispatch can override with the `channel`
+input (choices: `auto`, `stable`, `dev`, `none`).
+
+Dev releases use version suffix `~dev.YYYYMMDD.shortsha` (tilde ensures
+correct RPM/DEB version sorting so `dnf upgrade` / `apt upgrade` never moves
+stable users to dev). The `prerelease: true` flag on GitHub Releases ensures:
+- `/releases/latest` API skips dev releases
+- "Latest Release" badge on the repo page stays on stable
+- Yellow "Pre-release" badge appears on dev releases
+- Package manager repos (`claude-desktop.repo` vs `claude-desktop-dev.repo`)
+  point to separate gh-pages subdirectories (`/stable/` vs `/dev/`)
 
 ## GitHub Actions
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,69 @@ installs it to `~/.local/bin/`, and creates a systemd user service.  The app
 will warn on launch if the service is not running, but Chat and MCP still work
 without it.
 
+---
+
+### Beta / Development Channel (Testers Only)
+
+> **Not recommended for normal use.** The beta channel contains untested
+> development builds. They may be broken, crash on launch, or have incomplete
+> features. Use the [stable release](#installation) unless you are actively
+> testing changes.
+
+If you want to help test new features before they reach the stable channel:
+
+#### RPM / Fedora / Silverblue
+
+```sh
+sudo curl -o /etc/yum.repos.d/claude-desktop-dev.repo \
+  https://stslex.github.io/claude-desktop-linux/claude-desktop-dev.repo
+sudo dnf install claude-desktop
+```
+
+#### DEB / Debian / Ubuntu
+
+```sh
+sudo curl -o /etc/apt/sources.list.d/claude-desktop-dev.list \
+  https://stslex.github.io/claude-desktop-linux/claude-desktop-dev.list
+sudo apt update
+sudo apt install claude-desktop
+```
+
+#### Pacman / Arch Linux
+
+Add to `/etc/pacman.conf`:
+
+```ini
+[claude-desktop-dev]
+SigLevel = Optional TrustAll
+Server = https://github.com/stslex/claude-desktop-linux/releases/download/<dev-tag>
+```
+
+#### Rollback to stable
+
+If a beta build breaks your install:
+
+```sh
+# Fedora
+sudo dnf downgrade claude-desktop
+# or remove the dev repo and reinstall:
+sudo rm /etc/yum.repos.d/claude-desktop-dev.repo
+sudo dnf reinstall claude-desktop
+
+# Debian / Ubuntu
+sudo rm /etc/apt/sources.list.d/claude-desktop-dev.list
+sudo apt update
+sudo apt install claude-desktop --reinstall
+```
+
+#### Reporting beta issues
+
+Beta issues should be filed with the `beta` label on GitHub Issues.
+Include the exact version string from `rpm -q claude-desktop` or
+`claude-desktop --version`.
+
+---
+
 ### First Run
 
 1. No special setup needed — the app creates `~/.local/share/claude-linux/sessions/`

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -11,6 +11,8 @@ set -euo pipefail
 #   BUILD_DIR           default: /tmp/claude-build
 #   OUTPUT_DIR          default: ./output  (relative to repo root)
 #   ELECTRON_OVERRIDE   force a specific Electron version (e.g. 37.0.0)
+#   VERSION_SUFFIX      optional: appended to version in filename
+#                       (e.g. "~dev.20260404.abc1234" for dev channel)
 # ---------------------------------------------------------------------------
 
 log() { echo "[build-appimage] $*"; }

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -40,9 +40,11 @@ if [[ ! -f "$BUILD_DIR/ELECTRON_VERSION" ]]; then
 fi
 
 APP_VERSION="$(cat "$BUILD_DIR/VERSION")"
+VERSION_SUFFIX="${VERSION_SUFFIX:-}"
+FULL_VERSION="${APP_VERSION}${VERSION_SUFFIX}"
 ELECTRON_VERSION="${ELECTRON_OVERRIDE:-$(cat "$BUILD_DIR/ELECTRON_VERSION")}"
 
-log "Claude Desktop : $APP_VERSION"
+log "Claude Desktop : $FULL_VERSION"
 log "Electron       : $ELECTRON_VERSION"
 
 mkdir -p "$OUTPUT_DIR"
@@ -210,7 +212,7 @@ fi
 # ---------------------------------------------------------------------------
 # Build AppImage
 # ---------------------------------------------------------------------------
-APPIMAGE_OUT="$OUTPUT_DIR/claude-desktop-${APP_VERSION}-x86_64.AppImage"
+APPIMAGE_OUT="$OUTPUT_DIR/claude-desktop-${FULL_VERSION}-x86_64.AppImage"
 
 # Embed zsync update info so AppImageUpdate can fetch the latest release.
 # Pattern matches the repack-N filename used in GitHub releases.

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -38,8 +38,10 @@ if ! command -v dpkg-deb &>/dev/null; then
 fi
 
 VERSION="$(cat "$BUILD_DIR/VERSION")"
+VERSION_SUFFIX="${VERSION_SUFFIX:-}"
+FULL_VERSION="${VERSION}${VERSION_SUFFIX}"
 ELECTRON_VERSION="${ELECTRON_OVERRIDE:-$(cat "$BUILD_DIR/ELECTRON_VERSION")}"
-log "Version      : $VERSION"
+log "Version      : $FULL_VERSION"
 log "Electron     : $ELECTRON_VERSION"
 
 # ---------------------------------------------------------------------------
@@ -206,7 +208,7 @@ fi
 # Installed-Size is in KB, computed from the actual installed tree.
 INSTALLED_SIZE="$(du -sk "$DEB_ROOT/usr" | cut -f1)"
 # Include repack number in Debian version so apt detects newer repacks.
-DEB_VERSION="${VERSION}+repack${REPACK_NUM:-0}"
+DEB_VERSION="${FULL_VERSION}+repack${REPACK_NUM:-0}"
 
 cat > "$DEB_ROOT/DEBIAN/control" <<CTRL_EOF
 Package: claude-desktop
@@ -234,7 +236,7 @@ CTRL_EOF
 # Build .deb
 # ---------------------------------------------------------------------------
 mkdir -p "$OUTPUT_DIR"
-DEST_DEB="$OUTPUT_DIR/claude-desktop-${VERSION}-x86_64.deb"
+DEST_DEB="$OUTPUT_DIR/claude-desktop-${FULL_VERSION}-x86_64.deb"
 
 log "Building .deb package..."
 dpkg-deb --build --root-owner-group "$DEB_ROOT" "$DEST_DEB"

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -7,8 +7,10 @@ set -euo pipefail
 # Build a .deb package for Claude Desktop Linux.
 #
 # Env vars:
-#   BUILD_DIR      default: /tmp/claude-build
-#   OUTPUT_DIR     default: ./output  (relative to repo root)
+#   BUILD_DIR        default: /tmp/claude-build
+#   OUTPUT_DIR       default: ./output  (relative to repo root)
+#   VERSION_SUFFIX   optional: appended to version in filename/metadata
+#                    (e.g. "~dev.20260404.abc1234" for dev channel)
 # ---------------------------------------------------------------------------
 
 log() { echo "[build-deb] $*"; }

--- a/scripts/build-nix.sh
+++ b/scripts/build-nix.sh
@@ -9,8 +9,10 @@ set -euo pipefail
 # that can be consumed via the bundled flake.nix or other Nix packaging steps.
 #
 # Env vars:
-#   BUILD_DIR      default: /tmp/claude-build
-#   OUTPUT_DIR     default: ./output  (relative to repo root)
+#   BUILD_DIR        default: /tmp/claude-build
+#   OUTPUT_DIR       default: ./output  (relative to repo root)
+#   VERSION_SUFFIX   optional: appended to version in filename/metadata
+#                    (e.g. "~dev.20260404.abc1234" for dev channel)
 # ---------------------------------------------------------------------------
 
 log() { echo "[build-nix] $*"; }

--- a/scripts/build-nix.sh
+++ b/scripts/build-nix.sh
@@ -35,8 +35,10 @@ if [[ ! -d "$BUILD_DIR/app-extracted" ]]; then
 fi
 
 VERSION="$(cat "$BUILD_DIR/VERSION")"
+VERSION_SUFFIX="${VERSION_SUFFIX:-}"
+FULL_VERSION="${VERSION}${VERSION_SUFFIX}"
 ELECTRON_VERSION="${ELECTRON_OVERRIDE:-$(cat "$BUILD_DIR/ELECTRON_VERSION")}"
-log "Version      : $VERSION"
+log "Version      : $FULL_VERSION"
 log "Electron     : $ELECTRON_VERSION"
 
 # ---------------------------------------------------------------------------
@@ -156,13 +158,13 @@ if [[ -f "$SVG_ICON" ]]; then
 fi
 
 # Write version metadata
-echo "$VERSION" > "$NIX_ROOT/lib/claude-desktop/VERSION"
+echo "$FULL_VERSION" > "$NIX_ROOT/lib/claude-desktop/VERSION"
 
 # ---------------------------------------------------------------------------
 # Build tarball
 # ---------------------------------------------------------------------------
 mkdir -p "$OUTPUT_DIR"
-DEST_TAR="$OUTPUT_DIR/claude-desktop-${VERSION}-x86_64-nix.tar.gz"
+DEST_TAR="$OUTPUT_DIR/claude-desktop-${FULL_VERSION}-x86_64-nix.tar.gz"
 
 log "Building nix tarball..."
 tar -czf "$DEST_TAR" -C "$NIX_ROOT" .

--- a/scripts/build-packages.sh
+++ b/scripts/build-packages.sh
@@ -10,6 +10,8 @@ set -euo pipefail
 #   BUILD_DIR        default: /tmp/claude-build
 #   OUTPUT_DIR       default: ./output  (relative to repo root)
 #   KEEP_BUILD_DIR   set to 1 to preserve BUILD_DIR after the run
+#   VERSION_SUFFIX   optional: appended to version in filenames/metadata
+#                    (e.g. "~dev.20260404.abc1234" for dev channel)
 # ---------------------------------------------------------------------------
 
 log() { echo "[build-packages] $*"; }
@@ -47,7 +49,11 @@ if [[ ! -f "$BUILD_DIR/VERSION" ]]; then
 fi
 
 APP_VERSION="$(cat "$BUILD_DIR/VERSION")"
+VERSION_SUFFIX="${VERSION_SUFFIX:-}"
+FULL_VERSION="${APP_VERSION}${VERSION_SUFFIX}"
 log "Claude Desktop : $APP_VERSION"
+[[ -n "$VERSION_SUFFIX" ]] && log "Version suffix : $VERSION_SUFFIX"
+log "Full version   : $FULL_VERSION"
 
 # ---------------------------------------------------------------------------
 # Re-pack the patched app into app-patched.asar
@@ -63,7 +69,7 @@ mkdir -p "$OUTPUT_DIR"
 # ---------------------------------------------------------------------------
 log "--- RPM ---"
 RPM_OK=false
-if BUILD_DIR="$BUILD_DIR" OUTPUT_DIR="$OUTPUT_DIR" REPACK_NUM="${REPACK_NUM:-0}" "$SCRIPT_DIR/build-rpm.sh"; then
+if BUILD_DIR="$BUILD_DIR" OUTPUT_DIR="$OUTPUT_DIR" REPACK_NUM="${REPACK_NUM:-0}" VERSION_SUFFIX="$VERSION_SUFFIX" "$SCRIPT_DIR/build-rpm.sh"; then
     RPM_OK=true
     log "RPM build succeeded."
 else
@@ -75,7 +81,7 @@ fi
 # ---------------------------------------------------------------------------
 log "--- DEB ---"
 DEB_OK=false
-if BUILD_DIR="$BUILD_DIR" OUTPUT_DIR="$OUTPUT_DIR" REPACK_NUM="${REPACK_NUM:-0}" "$SCRIPT_DIR/build-deb.sh"; then
+if BUILD_DIR="$BUILD_DIR" OUTPUT_DIR="$OUTPUT_DIR" REPACK_NUM="${REPACK_NUM:-0}" VERSION_SUFFIX="$VERSION_SUFFIX" "$SCRIPT_DIR/build-deb.sh"; then
     DEB_OK=true
     log "DEB build succeeded."
 else
@@ -87,7 +93,7 @@ fi
 # ---------------------------------------------------------------------------
 log "--- Pacman ---"
 PACMAN_OK=false
-if BUILD_DIR="$BUILD_DIR" OUTPUT_DIR="$OUTPUT_DIR" REPACK="${REPACK_NUM:-0}" "$SCRIPT_DIR/build-pacman.sh"; then
+if BUILD_DIR="$BUILD_DIR" OUTPUT_DIR="$OUTPUT_DIR" REPACK="${REPACK_NUM:-0}" VERSION_SUFFIX="$VERSION_SUFFIX" "$SCRIPT_DIR/build-pacman.sh"; then
     PACMAN_OK=true
     log "Pacman build succeeded."
 else
@@ -99,7 +105,7 @@ fi
 # ---------------------------------------------------------------------------
 log "--- Nix ---"
 NIX_OK=false
-if BUILD_DIR="$BUILD_DIR" OUTPUT_DIR="$OUTPUT_DIR" "$SCRIPT_DIR/build-nix.sh"; then
+if BUILD_DIR="$BUILD_DIR" OUTPUT_DIR="$OUTPUT_DIR" VERSION_SUFFIX="$VERSION_SUFFIX" "$SCRIPT_DIR/build-nix.sh"; then
     NIX_OK=true
     log "Nix build succeeded."
 else
@@ -111,7 +117,7 @@ fi
 # ---------------------------------------------------------------------------
 log "--- AppImage ---"
 APPIMAGE_OK=false
-if BUILD_DIR="$BUILD_DIR" OUTPUT_DIR="$OUTPUT_DIR" "$SCRIPT_DIR/build-appimage.sh"; then
+if BUILD_DIR="$BUILD_DIR" OUTPUT_DIR="$OUTPUT_DIR" VERSION_SUFFIX="$VERSION_SUFFIX" "$SCRIPT_DIR/build-appimage.sh"; then
     APPIMAGE_OK=true
     log "AppImage build succeeded."
 else
@@ -151,11 +157,11 @@ verify_sha256() {
     fi
 }
 
-RPM_PKG="$OUTPUT_DIR/claude-desktop-${APP_VERSION}-x86_64.rpm"
-DEB_PKG="$OUTPUT_DIR/claude-desktop-${APP_VERSION}-x86_64.deb"
-PACMAN_PKG="$OUTPUT_DIR/claude-desktop-${APP_VERSION}-x86_64.pkg.tar.zst"
-NIX_PKG="$OUTPUT_DIR/claude-desktop-${APP_VERSION}-x86_64-nix.tar.gz"
-APPIMAGE_PKG="$OUTPUT_DIR/claude-desktop-${APP_VERSION}-x86_64.AppImage"
+RPM_PKG="$OUTPUT_DIR/claude-desktop-${FULL_VERSION}-x86_64.rpm"
+DEB_PKG="$OUTPUT_DIR/claude-desktop-${FULL_VERSION}-x86_64.deb"
+PACMAN_PKG="$OUTPUT_DIR/claude-desktop-${FULL_VERSION}-x86_64.pkg.tar.zst"
+NIX_PKG="$OUTPUT_DIR/claude-desktop-${FULL_VERSION}-x86_64-nix.tar.gz"
+APPIMAGE_PKG="$OUTPUT_DIR/claude-desktop-${FULL_VERSION}-x86_64.AppImage"
 
 [[ -f "$RPM_PKG"      ]] && verify_sha256 "$RPM_PKG"      || true
 [[ -f "$DEB_PKG"      ]] && verify_sha256 "$DEB_PKG"      || true

--- a/scripts/build-pacman.sh
+++ b/scripts/build-pacman.sh
@@ -43,9 +43,11 @@ for cmd in bsdtar zstd unzip; do
 done
 
 VERSION="$(cat "$BUILD_DIR/VERSION")"
+VERSION_SUFFIX="${VERSION_SUFFIX:-}"
+FULL_VERSION="${VERSION}${VERSION_SUFFIX}"
 ELECTRON_VERSION="${ELECTRON_OVERRIDE:-$(cat "$BUILD_DIR/ELECTRON_VERSION")}"
 PKGREL="${REPACK:-1}"
-log "Version      : $VERSION"
+log "Version      : $FULL_VERSION"
 log "Electron     : $ELECTRON_VERSION"
 log "Pkg release  : $PKGREL"
 
@@ -172,7 +174,7 @@ INSTALL_SIZE="$(du -sb "$PKG_ROOT/usr" | awk '{print $1}')"
 cat > "$PKG_ROOT/.PKGINFO" <<PKGINFO_EOF
 pkgname = claude-desktop
 pkgbase = claude-desktop
-pkgver = ${VERSION}-${PKGREL}
+pkgver = ${FULL_VERSION}-${PKGREL}
 xdata = pkgtype=pkg
 pkgdesc = Claude Desktop for Linux (unofficial rebuild)
 url = https://github.com/stslex/claude-desktop-linux
@@ -271,7 +273,7 @@ fi
 # Build .pkg.tar.zst using bsdtar
 # ---------------------------------------------------------------------------
 mkdir -p "$OUTPUT_DIR"
-DEST_PKG="$OUTPUT_DIR/claude-desktop-${VERSION}-x86_64.pkg.tar.zst"
+DEST_PKG="$OUTPUT_DIR/claude-desktop-${FULL_VERSION}-x86_64.pkg.tar.zst"
 
 log "Building pacman package..."
 # bsdtar must run from the package root so paths are relative

--- a/scripts/build-pacman.sh
+++ b/scripts/build-pacman.sh
@@ -7,9 +7,11 @@ set -euo pipefail
 # Build an Arch Linux .pkg.tar.zst package for Claude Desktop Linux.
 #
 # Env vars:
-#   BUILD_DIR      default: /tmp/claude-build
-#   OUTPUT_DIR     default: ./output  (relative to repo root)
-#   REPACK         default: 1  (repack number, used as pkgrel)
+#   BUILD_DIR        default: /tmp/claude-build
+#   OUTPUT_DIR       default: ./output  (relative to repo root)
+#   REPACK           default: 1  (repack number, used as pkgrel)
+#   VERSION_SUFFIX   optional: appended to version in filename/metadata
+#                    (e.g. "~dev.20260404.abc1234" for dev channel)
 # ---------------------------------------------------------------------------
 
 log() { echo "[build-pacman] $*"; }

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -39,8 +39,10 @@ if ! command -v rpmbuild &>/dev/null; then
 fi
 
 VERSION="$(cat "$BUILD_DIR/VERSION")"
+VERSION_SUFFIX="${VERSION_SUFFIX:-}"
+FULL_VERSION="${VERSION}${VERSION_SUFFIX}"
 ELECTRON_VERSION="${ELECTRON_OVERRIDE:-$(cat "$BUILD_DIR/ELECTRON_VERSION")}"
-log "Version      : $VERSION"
+log "Version      : $FULL_VERSION"
 log "Electron     : $ELECTRON_VERSION"
 
 # ---------------------------------------------------------------------------
@@ -140,14 +142,14 @@ cp "$REPO_DIR/packaging/claude-desktop.spec" "$RPM_ROOT/SPECS/claude-desktop.spe
 # ---------------------------------------------------------------------------
 # Build RPM
 # ---------------------------------------------------------------------------
-log "Running rpmbuild $VERSION ..."
+log "Running rpmbuild $FULL_VERSION ..."
 
 REPACK_NUM="${REPACK_NUM:-0}"
 log "Repack       : $REPACK_NUM"
 
 RPMBUILD_ARGS=(
     --define "_topdir $RPM_ROOT"
-    --define "_version $VERSION"
+    --define "_version $FULL_VERSION"
     --define "_repack $REPACK_NUM"
     -bb "$RPM_ROOT/SPECS/claude-desktop.spec"
 )
@@ -170,7 +172,7 @@ if [[ -z "$RPM_FILE" ]]; then
 fi
 
 mkdir -p "$OUTPUT_DIR"
-DEST_RPM="$OUTPUT_DIR/claude-desktop-${VERSION}-x86_64.rpm"
+DEST_RPM="$OUTPUT_DIR/claude-desktop-${FULL_VERSION}-x86_64.rpm"
 cp "$RPM_FILE" "$DEST_RPM"
 sha256sum "$DEST_RPM" | awk '{print $1}' > "${DEST_RPM}.sha256"
 

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -7,9 +7,11 @@ set -euo pipefail
 # Re-pack the patched ASAR and build an RPM from it.
 #
 # Env vars:
-#   BUILD_DIR      default: /tmp/claude-build
-#   OUTPUT_DIR     default: ./output  (relative to repo root)
-#   GPG_KEY_ID     optional: sign the RPM with this key ID
+#   BUILD_DIR        default: /tmp/claude-build
+#   OUTPUT_DIR       default: ./output  (relative to repo root)
+#   GPG_KEY_ID       optional: sign the RPM with this key ID
+#   VERSION_SUFFIX   optional: appended to version in filename/metadata
+#                    (e.g. "~dev.20260404.abc1234" for dev channel)
 # ---------------------------------------------------------------------------
 
 log() { echo "[build-rpm] $*"; }

--- a/stubs/claude-swift.js
+++ b/stubs/claude-swift.js
@@ -14,9 +14,6 @@ let _callbacks = {};
 /** @type {Map<number, import('child_process').ChildProcess>} */
 const _procs = new Map();
 
-/** Lifecycle state — set by startVM, cleared by stopVM. */
-let _started = false;
-
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -212,7 +209,6 @@ const _vmBase = {
    * @returns {Promise<void>}
    */
   startVM(_config) {
-    _started = true;
     return new Promise((resolve) => {
       setImmediate(() => {
         if (typeof _callbacks.onReady === 'function') _callbacks.onReady();
@@ -306,11 +302,11 @@ const _vmBase = {
 
   /**
    * Report whether the "guest" (VM/process) is connected.
-   * On Linux we spawn processes directly, so if started, the guest is always connected.
+   * On Linux there is no VM — always return true so the orchestrator proceeds.
    * @returns {boolean}
    */
   isGuestConnected() {
-    return _started;
+    return true;
   },
 
   /**
@@ -321,7 +317,6 @@ const _vmBase = {
       try { child.kill('SIGTERM'); } catch {}
     }
     _procs.clear();
-    _started = false;
     setImmediate(() => {
       if (typeof _callbacks.onExit === 'function') _callbacks.onExit();
     });
@@ -329,28 +324,31 @@ const _vmBase = {
 
   /**
    * Report whether the VM is running.
+   * On Linux there is no VM — always return true.
    * @returns {boolean}
    */
   isRunning() {
-    return _started;
+    return true;
   },
 
   /**
    * Report whether the VM is ready.
+   * On Linux there is no VM — always return true.
    * @returns {boolean}
    */
   isReady() {
-    return _started;
+    return true;
   },
 };
 
 // Getter-style properties that the orchestrator may check as properties or methods.
+// On Linux there is no VM — always report started/reachable.
 Object.defineProperty(_vmBase, 'vmStarted', {
-  get() { return _started; },
+  get() { return true; },
   enumerable: true,
 });
 Object.defineProperty(_vmBase, 'apiReachable', {
-  get() { return _started; },
+  get() { return true; },
   enumerable: true,
 });
 


### PR DESCRIPTION
## Summary

- **Fix startup regression** from PR #49: `isRunning()`, `isReady()`, `isGuestConnected()`, `vmStarted`, and `apiReachable` were changed to return `_started` (initially `false`). The orchestrator checks these before calling `startVM()`, causing a deadlock. Restored unconditional `return true` — on Linux there is no VM.

- **Add dual-channel release system** (stable + dev/beta):
  - `main` branch → stable GitHub Release, `/stable/` gh-pages directory
  - `dev` branch → pre-release GitHub Release (`prerelease: true`), `/dev/` gh-pages directory
  - PRs → workflow artifacts only, no release or publishing
  - Dev builds use `~dev.YYYYMMDD.shortsha` version suffix (tilde ensures correct RPM/DEB sort order — `dnf upgrade` never moves stable users to dev)
  - Separate `.repo`/`.list` files: `claude-desktop.repo` (stable) vs `claude-desktop-dev.repo` (dev)
  - Backward-compatible aliases at `/rpm/`, `/deb/`, `/nix/` for existing stable users

- **Docs**: README beta channel section with install/rollback instructions; CLAUDE.MD release channels table

## Files changed

| Area | Files |
|------|-------|
| Startup fix | `stubs/claude-swift.js` |
| CI workflow | `.github/workflows/build.yml` |
| Build scripts | `scripts/build-{packages,rpm,deb,pacman,appimage,nix}.sh` |
| Docs | `README.md`, `CLAUDE.MD` |

## Test plan

- [ ] Push to `dev` → verify prerelease with `[BETA]` prefix appears on Releases page
- [ ] Push to `main` → verify regular release appears and becomes "Latest"
- [ ] Verify `claude-desktop-dev.repo` resolves on gh-pages
- [ ] Verify stable users with old `/rpm/` repo URL still work (backward-compat alias)
- [ ] Verify `dnf` version sorting: `1.569.0~dev.20260404.abc1234` < `1.569.0`
- [ ] Launch `claude-desktop` — confirm it starts (no `isRunning()` deadlock)

https://claude.ai/code/session_01QPWAQdrrtXHzEprmQiZFDC