### PR TITLE
fix: address PR #50 review — CJS imports, callback consistency, syste…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,8 @@ on:
       - dev
     tags:
       - 'v*'
+      - '!v*-repack-*'
+      - '!v*~dev.*'
   pull_request:
     branches: ['dev', 'main']
   workflow_dispatch:

--- a/packaging/AppDir/AppRun
+++ b/packaging/AppDir/AppRun
@@ -35,8 +35,9 @@ mkdir -p "$HOME/.local/share/claude-linux/sessions"
 # Cowork service check (optional — Cowork/Dispatch via socket protocol).
 # ---------------------------------------------------------------------------
 if ! pgrep -x cowork-svc-linux &>/dev/null && \
-   ! systemctl --user is-active claude-cowork &>/dev/null 2>&1; then
-  echo "[claude-desktop] WARN: claude-cowork service not running. Cowork features will not work." >&2
+   { ! command -v systemctl &>/dev/null || ! systemctl --user is-active claude-cowork &>/dev/null 2>&1; }; then
+  echo "[claude-desktop] WARN: claude-cowork service not running. Socket-based and Dispatch Cowork features will be unavailable." >&2
+  echo "  Other Cowork backends (stub/bwrap/host) remain functional." >&2
   echo "  Run: scripts/install-cowork-service.sh" >&2
 fi
 

--- a/packaging/AppDir/usr/bin/claude-desktop
+++ b/packaging/AppDir/usr/bin/claude-desktop
@@ -69,8 +69,9 @@ fi
 # Cowork service check (optional — Cowork/Dispatch via socket protocol).
 # ---------------------------------------------------------------------------
 if ! pgrep -x cowork-svc-linux &>/dev/null && \
-   ! systemctl --user is-active claude-cowork &>/dev/null 2>&1; then
-    echo "[claude-desktop] WARN: claude-cowork service not running. Cowork features will not work." >&2
+   { ! command -v systemctl &>/dev/null || ! systemctl --user is-active claude-cowork &>/dev/null 2>&1; }; then
+    echo "[claude-desktop] WARN: claude-cowork service not running. Socket-based and Dispatch Cowork features will be unavailable." >&2
+    echo "  Other Cowork backends (stub/bwrap/host) remain functional." >&2
     echo "  Run: scripts/install-cowork-service.sh" >&2
 fi
 

--- a/scripts/install-cowork-service.sh
+++ b/scripts/install-cowork-service.sh
@@ -50,6 +50,8 @@ check_dep() {
   fi
 }
 
+check_dep node "Install Node.js (required for JSON parsing)."
+check_dep systemctl "This script requires systemd. Non-systemd systems are not supported."
 check_dep sha256sum "Install coreutils."
 
 DOWNLOADER=""

--- a/scripts/patch-cowork.sh
+++ b/scripts/patch-cowork.sh
@@ -454,6 +454,8 @@ sed \
   -e "s/^import path from 'path';/const path = require('path');/" \
   -e "s/^import fs   from 'fs';/const fs   = require('fs');/" \
   -e "s/^import os   from 'os';/const os   = require('os');/" \
+  -e "s/^import child_process from 'child_process';/const child_process = require('child_process');/" \
+  -e "s/^import net  from 'net';/const net  = require('net');/" \
   -e "s/^export function translatePath/module.exports.translatePath = function translatePath/" \
   "$TRANSLATOR_SRC" > "$TRANSLATOR_DEST"
 log "Copied path-translator to $TRANSLATOR_DEST"

--- a/stubs/claude-swift.js
+++ b/stubs/claude-swift.js
@@ -313,13 +313,14 @@ const _vmBase = {
    * Stop the VM — on Linux, kill all tracked child processes and reset state.
    */
   stopVM() {
-    for (const [, child] of _procs) {
+    for (const [pid, child] of _procs) {
       try { child.kill('SIGTERM'); } catch {}
+      // Fire per-child onExit with consistent signature
+      if (typeof _callbacks.onExit === 'function') {
+        setImmediate(() => _callbacks.onExit(pid, null, 'SIGTERM'));
+      }
     }
     _procs.clear();
-    setImmediate(() => {
-      if (typeof _callbacks.onExit === 'function') _callbacks.onExit();
-    });
   },
 
   /**


### PR DESCRIPTION
…mctl guard

- patch-cowork.sh: convert child_process and net ESM imports to CJS require() so the built bundle doesn't contain unconverted import statements
- claude-swift.js: call onExit(pid, null, 'SIGTERM') with consistent signature in stopVM() instead of zero-argument invocation
- AppRun/claude-desktop: guard systemctl call with `command -v` for non-systemd systems; clarify warning to specify only socket/Dispatch features are affected
- build.yml: exclude generated tags (*-repack-*, *~dev.*) from push triggers to prevent infinite build loops
- install-cowork-service.sh: add explicit node and systemctl dependency checks

https://claude.ai/code/session_01U5pWxpDWDNidYcutkgJxSg