### PR TITLE
Add actions:read permission to GitHub Pages deployment job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -663,6 +663,7 @@ jobs:
     permissions:
       pages: write
       id-token: write
+      actions: read
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
Added the `actions: read` permission to the GitHub Pages deployment workflow job to enable reading workflow run information.

## Changes
- Added `actions: read` permission to the `permissions` block in the GitHub Pages deployment job

## Details
This permission allows the deployment job to read GitHub Actions workflow data, which may be necessary for the deployment process to access workflow run information or artifacts. This follows the principle of least privilege by explicitly declaring required permissions.

https://claude.ai/code/session_01K4aBD5WGnN5uhCeN2uQThb