### PR TITLE
fix: handle dev release re-runs and restrict pages deploy to stable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -380,6 +380,10 @@ jobs:
             exit 1
           fi
 
+          # Delete existing release if this is a re-run for the same commit
+          gh release delete "${TAG}" --repo "${{ github.repository }}" --yes 2>/dev/null || true
+          git push origin :"refs/tags/${TAG}" 2>/dev/null || true
+
           gh release create "${TAG}" \
             --repo "${{ github.repository }}" \
             --title "[BETA] Claude Desktop Linux v${VERSION} dev.${DEV_BUILD_DATE}.${DEV_SHORT_SHA}" \
@@ -656,9 +660,7 @@ jobs:
   # ---------------------------------------------------------------------------
   deploy-pages:
     needs: [determine-channel, build]
-    if: >
-      needs.determine-channel.outputs.channel == 'stable' ||
-      needs.determine-channel.outputs.channel == 'dev'
+    if: needs.determine-channel.outputs.channel == 'stable'
     runs-on: ubuntu-latest
     permissions:
       pages: write


### PR DESCRIPTION
Two CI fixes:

1. Dev release creation now deletes existing release/tag before creating a new one, preventing failures on workflow re-runs for the same commit.

2. GitHub Pages deployment is now restricted to the stable channel only. The dev branch is blocked by github-pages environment protection rules, and dev deploys would overwrite stable repo metadata anyway.

https://claude.ai/code/session_01K4aBD5WGnN5uhCeN2uQThb