### PR TITLE
fix: restore deploy-pages for both stable and dev channels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -660,7 +660,9 @@ jobs:
   # ---------------------------------------------------------------------------
   deploy-pages:
     needs: [determine-channel, build]
-    if: needs.determine-channel.outputs.channel == 'stable'
+    if: >
+      needs.determine-channel.outputs.channel == 'stable' ||
+      needs.determine-channel.outputs.channel == 'dev'
     runs-on: ubuntu-latest
     permissions:
       pages: write


### PR DESCRIPTION
Re-enable pages deployment for the dev channel. The github-pages environment protection rules need to be updated in repo settings to allow the dev branch (Settings → Environments → github-pages → Deployment branches → add dev).

https://claude.ai/code/session_01K4aBD5WGnN5uhCeN2uQThb