### PR TITLE
feat (pr review fix): enable Cowork and Dispatch on Linux via socket IPC

### DIFF
--- a/packaging/AppDir/AppRun
+++ b/packaging/AppDir/AppRun
@@ -33,13 +33,17 @@ mkdir -p "$HOME/.local/share/claude-linux/sessions"
 
 # ---------------------------------------------------------------------------
 # Cowork service check (optional — Cowork/Dispatch via socket protocol).
+# NOTE: Keep in sync with packaging/AppDir/usr/bin/claude-desktop.
 # ---------------------------------------------------------------------------
-if ! pgrep -x cowork-svc-linux &>/dev/null && \
-   { ! command -v systemctl &>/dev/null || ! systemctl --user is-active claude-cowork &>/dev/null 2>&1; }; then
-  echo "[claude-desktop] WARN: claude-cowork service not running. Socket-based and Dispatch Cowork features will be unavailable." >&2
-  echo "  Other Cowork backends (stub/bwrap/host) remain functional." >&2
-  echo "  Run: scripts/install-cowork-service.sh" >&2
-fi
+check_cowork_service() {
+  if ! pgrep -x cowork-svc-linux &>/dev/null && \
+     { ! command -v systemctl &>/dev/null || ! systemctl --user is-active claude-cowork &>/dev/null 2>&1; }; then
+    echo "[claude-desktop] WARN: claude-cowork service not running. Socket-based and Dispatch Cowork features will be unavailable." >&2
+    echo "  Other Cowork backends (stub/bwrap/host) remain functional." >&2
+    echo "  Run: scripts/install-cowork-service.sh" >&2
+  fi
+}
+check_cowork_service
 
 # ---------------------------------------------------------------------------
 # Cowork backend selection.

--- a/packaging/AppDir/usr/bin/claude-desktop
+++ b/packaging/AppDir/usr/bin/claude-desktop
@@ -67,13 +67,17 @@ fi
 
 # ---------------------------------------------------------------------------
 # Cowork service check (optional — Cowork/Dispatch via socket protocol).
+# NOTE: Keep in sync with packaging/AppDir/AppRun.
 # ---------------------------------------------------------------------------
-if ! pgrep -x cowork-svc-linux &>/dev/null && \
-   { ! command -v systemctl &>/dev/null || ! systemctl --user is-active claude-cowork &>/dev/null 2>&1; }; then
-    echo "[claude-desktop] WARN: claude-cowork service not running. Socket-based and Dispatch Cowork features will be unavailable." >&2
-    echo "  Other Cowork backends (stub/bwrap/host) remain functional." >&2
-    echo "  Run: scripts/install-cowork-service.sh" >&2
-fi
+check_cowork_service() {
+    if ! pgrep -x cowork-svc-linux &>/dev/null && \
+       { ! command -v systemctl &>/dev/null || ! systemctl --user is-active claude-cowork &>/dev/null 2>&1; }; then
+        echo "[claude-desktop] WARN: claude-cowork service not running. Socket-based and Dispatch Cowork features will be unavailable." >&2
+        echo "  Other Cowork backends (stub/bwrap/host) remain functional." >&2
+        echo "  Run: scripts/install-cowork-service.sh" >&2
+    fi
+}
+check_cowork_service
 
 # ---------------------------------------------------------------------------
 # Cowork backend selection.

--- a/patches/patch-computer-use-tcc.mjs
+++ b/patches/patch-computer-use-tcc.mjs
@@ -20,10 +20,10 @@
  *   node patches/patch-computer-use-tcc.mjs <app-extracted-dir>
  */
 
-import { readFileSync, writeFileSync, readdirSync } from 'fs';
+import { readFileSync, writeFileSync } from 'fs';
 import { join, relative } from 'path';
-import * as acorn from 'acorn';
 import * as walk from 'acorn-walk';
+import { collectJsFiles, tryParse, createLogger } from './patch-utils.mjs';
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -44,48 +44,18 @@ const TCC_CHANNELS = [
 // `;` can trigger ASI issues if the previous token was mid-expression.  By
 // starting with `;` on the same (first) line we guarantee a clean statement
 // boundary regardless of what precedes it.
-const STUB_SNIPPET = `;(function(){try{var e=require("electron"),m=e.ipcMain;if(m){` +
-  `var ch=["ComputerUseTcc:getState","ComputerUseTcc:requestAccess",` +
-  `"ComputerUseTcc.getState","ComputerUseTcc.requestPermission",` +
-  `"ComputerUseTcc.checkAccessibility","ComputerUseTcc.checkScreenRecording",` +
-  `"ComputerUseTcc.requestAccessibility","ComputerUseTcc.requestScreenRecording"];` +
-  `var r={status:"not_applicable"};` +
-  `ch.forEach(function(c){try{m.handle(c,function(){return r})}catch(x){}});` +
-  `}}catch(x){}})();\n`;
+const STUB_SNIPPET = [
+  `;(function(){try{var e=require("electron"),m=e.ipcMain;if(m){`,
+  `var ch=${JSON.stringify(TCC_CHANNELS)};`,
+  `var r={status:"not_applicable"};`,
+  `ch.forEach(function(c){try{m.handle(c,function(){return r})}catch(x){}});`,
+  `}}catch(x){}})();\n`,
+].join('');
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-const log = (msg) => process.stderr.write(`[patch-computer-use-tcc] ${msg}\n`);
-
-function collectJsFiles(dir) {
-  const files = [];
-  try {
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      const full = join(dir, entry.name);
-      if (entry.isDirectory()) {
-        files.push(...collectJsFiles(full));
-      } else if (entry.name.endsWith('.js')) {
-        files.push(full);
-      }
-    }
-  } catch (e) {
-    log(`WARNING: Cannot read ${dir}: ${e.message}`);
-  }
-  return files;
-}
-
-function tryParse(src, file) {
-  for (const sourceType of ['module', 'script']) {
-    try {
-      return acorn.parse(src, {
-        ecmaVersion: 'latest',
-        sourceType,
-      });
-    } catch (_) {}
-  }
-  return null;
-}
+const log = createLogger('patch-computer-use-tcc');
 
 // ---------------------------------------------------------------------------
 // Main
@@ -118,7 +88,7 @@ for (const scanDir of scanDirs) {
 
     if (!src.includes('ComputerUseTcc') && !src.includes('ipcMain')) continue;
 
-    const ast = tryParse(src, file);
+    const ast = tryParse(src, file, {}, log);
     if (!ast) continue;
 
     const relFile = relative(appDir, file);

--- a/patches/patch-cowork-socket.mjs
+++ b/patches/patch-cowork-socket.mjs
@@ -17,10 +17,10 @@
  * Exits 0 on success, 1 if the pattern is not found.
  */
 
-import { readFileSync, writeFileSync, readdirSync, statSync } from 'fs';
+import { readFileSync, writeFileSync } from 'fs';
 import { join, relative } from 'path';
-import * as acorn from 'acorn';
 import * as walk from 'acorn-walk';
+import { collectJsFiles, tryParse, createLogger } from './patch-utils.mjs';
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -42,40 +42,7 @@ const PLATFORM_LINUX_ADDITION = `||process.platform==="linux"`;
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-const log = (msg) => process.stderr.write(`[patch-cowork-socket] ${msg}\n`);
-
-function collectJsFiles(dir) {
-  const files = [];
-  try {
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      const full = join(dir, entry.name);
-      if (entry.isDirectory()) {
-        files.push(...collectJsFiles(full));
-      } else if (entry.name.endsWith('.js')) {
-        files.push(full);
-      }
-    }
-  } catch (e) {
-    log(`WARNING: Cannot read ${dir}: ${e.message}`);
-  }
-  return files;
-}
-
-function tryParse(src, file) {
-  for (const sourceType of ['module', 'script']) {
-    try {
-      return acorn.parse(src, {
-        ecmaVersion: 'latest',
-        sourceType,
-        locations: true,
-      });
-    } catch (_) {
-      // try next sourceType
-    }
-  }
-  log(`WARNING: Could not parse ${file} — skipping.`);
-  return null;
-}
+const log = createLogger('patch-cowork-socket');
 
 function collectStrings(node) {
   const strings = new Set();
@@ -131,7 +98,7 @@ for (const scanDir of scanDirs) {
 
     if (!hasPipeRef && !hasPlatformGuard) continue;
 
-    const ast = tryParse(src, file);
+    const ast = tryParse(src, file, { locations: true }, log);
     if (!ast) continue;
 
     const relFile = relative(appDir, file);
@@ -291,7 +258,7 @@ if (pipeMatches.length === 0 && platformGuardMatches.length === 0) {
       }
       if (!src.includes('cowork') && !src.includes('pipe')) continue;
 
-      const ast = tryParse(src, file);
+      const ast = tryParse(src, file, { locations: true }, log);
       if (!ast) continue;
 
       const relFile = relative(appDir, file);

--- a/patches/patch-dispatch.mjs
+++ b/patches/patch-dispatch.mjs
@@ -17,10 +17,10 @@
  * Exits 0 on success, 1 if critical sub-patches fail.
  */
 
-import { readFileSync, writeFileSync, readdirSync, statSync } from 'fs';
+import { readFileSync, writeFileSync } from 'fs';
 import { join, relative } from 'path';
-import * as acorn from 'acorn';
 import * as walk from 'acorn-walk';
+import { collectJsFiles, tryParse, createLogger } from './patch-utils.mjs';
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -34,40 +34,7 @@ const FLAG_HASHES = {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-const log = (msg) => process.stderr.write(`[patch-dispatch] ${msg}\n`);
-
-function collectJsFiles(dir) {
-  const files = [];
-  try {
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      const full = join(dir, entry.name);
-      if (entry.isDirectory()) {
-        files.push(...collectJsFiles(full));
-      } else if (entry.name.endsWith('.js')) {
-        files.push(full);
-      }
-    }
-  } catch (e) {
-    log(`WARNING: Cannot read ${dir}: ${e.message}`);
-  }
-  return files;
-}
-
-function tryParse(src, file) {
-  for (const sourceType of ['module', 'script']) {
-    try {
-      return acorn.parse(src, {
-        ecmaVersion: 'latest',
-        sourceType,
-        locations: true,
-      });
-    } catch (_) {
-      // try next sourceType
-    }
-  }
-  log(`WARNING: Could not parse ${file} — skipping.`);
-  return null;
-}
+const log = createLogger('patch-dispatch');
 
 /**
  * Walk ancestors to find the nearest enclosing scope (function or block).
@@ -97,8 +64,11 @@ function findEnclosingScope(ancestors) {
 function findNearbyBooleanInit(ast, src, flagNode, scope) {
   const candidates = [];
 
-  walk.simple(scope, {
-    UnaryExpression(node) {
+  // Use ancestor walk so we can verify the boolean is in a VariableDeclarator
+  // init or AssignmentExpression right-hand side — not an arbitrary expression
+  // like a function argument or conditional test.
+  walk.ancestor(scope, {
+    UnaryExpression(node, _state, ancestors) {
       // Match `!0` (true) or `!1` (false)
       if (
         node.operator === '!' &&
@@ -106,6 +76,17 @@ function findNearbyBooleanInit(ast, src, flagNode, scope) {
         node.argument.type === 'Literal' &&
         (node.argument.value === 0 || node.argument.value === 1)
       ) {
+        // Verify this boolean is an initializer or assignment target, not
+        // an arbitrary expression (e.g. function argument, return value).
+        const parent = ancestors[ancestors.length - 2];
+        const isVarInit = parent &&
+          parent.type === 'VariableDeclarator' &&
+          parent.init === node;
+        const isAssignment = parent &&
+          parent.type === 'AssignmentExpression' &&
+          parent.right === node;
+        if (!isVarInit && !isAssignment) return;
+
         candidates.push({
           start: node.start,
           end: node.end,
@@ -222,7 +203,7 @@ for (const scanDir of scanDirs) {
 
     if (!hasAnyHash && !hasPlatformLabel) continue;
 
-    const ast = tryParse(src, file);
+    const ast = tryParse(src, file, { locations: true }, log);
     if (!ast) continue;
 
     const relFile = relative(appDir, file);

--- a/patches/patch-utils.mjs
+++ b/patches/patch-utils.mjs
@@ -1,0 +1,67 @@
+/**
+ * patch-utils.mjs
+ *
+ * Shared utilities for AST-based patches.  All three patch scripts
+ * (patch-cowork-socket, patch-dispatch, patch-computer-use-tcc)
+ * previously duplicated these helpers.
+ */
+
+import { readdirSync } from 'fs';
+import { join } from 'path';
+import * as acorn from 'acorn';
+
+/**
+ * Recursively collect all .js files under `dir`.
+ * @param {string} dir
+ * @param {(msg: string) => void} [log] — optional logger for warnings
+ * @returns {string[]}
+ */
+export function collectJsFiles(dir, log) {
+  const files = [];
+  try {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        files.push(...collectJsFiles(full, log));
+      } else if (entry.name.endsWith('.js')) {
+        files.push(full);
+      }
+    }
+  } catch (e) {
+    if (log) log(`WARNING: Cannot read ${dir}: ${e.message}`);
+  }
+  return files;
+}
+
+/**
+ * Try to parse `src` as ESM first, then as CJS script.
+ * @param {string} src
+ * @param {string} file — path (used only in warning messages)
+ * @param {object} [extraOpts] — additional acorn options (e.g. `{ locations: true }`)
+ * @param {(msg: string) => void} [log]
+ * @returns {import('acorn').Node | null}
+ */
+export function tryParse(src, file, extraOpts, log) {
+  for (const sourceType of ['module', 'script']) {
+    try {
+      return acorn.parse(src, {
+        ecmaVersion: 'latest',
+        sourceType,
+        ...extraOpts,
+      });
+    } catch (_) {
+      // try next sourceType
+    }
+  }
+  if (log) log(`WARNING: Could not parse ${file} — skipping.`);
+  return null;
+}
+
+/**
+ * Create a prefixed logger that writes to stderr.
+ * @param {string} prefix — e.g. "patch-cowork-socket"
+ * @returns {(msg: string) => void}
+ */
+export function createLogger(prefix) {
+  return (msg) => process.stderr.write(`[${prefix}] ${msg}\n`);
+}

--- a/patches/path-translator.mjs
+++ b/patches/path-translator.mjs
@@ -272,9 +272,19 @@ if (!global[INIT_SYM] && process.type === 'browser') {
 
   const _origExec = child_process.exec.bind(child_process);
   child_process.exec = (cmd, ...rest) => {
-    // exec takes a command string — translate any /sessions/ paths in it
+    // exec takes a command string — translate any /sessions/ paths in it.
+    // We handle both unquoted and quoted paths:
+    //   unquoted: /sessions/uuid/mnt/name/file.txt  (stop at whitespace or shell metachar)
+    //   single-quoted: '/sessions/uuid/mnt/name/file with spaces.txt'
+    //   double-quoted: "/sessions/uuid/mnt/name/file with spaces.txt"
     if (typeof cmd === 'string') {
-      cmd = cmd.replace(/\/sessions\/[^\s'"]+/g, (match) => translatePath(match));
+      cmd = cmd
+        // Single-quoted paths: translate content, re-wrap in single quotes
+        .replace(/'(\/sessions\/[^']+)'/g, (_m, p) => `'${translatePath(p)}'`)
+        // Double-quoted paths: translate content, re-wrap in double quotes
+        .replace(/"(\/sessions\/[^"]+)"/g, (_m, p) => `"${translatePath(p)}"`)
+        // Unquoted paths: stop at whitespace, quotes, or common shell metacharacters
+        .replace(/(?<=['"\s]|^)(\/sessions\/[^\s'";&|<>()]+)/g, (_m, p) => translatePath(p));
     }
     return _origExec(cmd, ...rest);
   };

--- a/scripts/install-cowork-service.sh
+++ b/scripts/install-cowork-service.sh
@@ -38,7 +38,14 @@ SERVICE_FILE="$SYSTEMD_DIR/${SERVICE_NAME}.service"
 SOCKET_NAME="cowork-vm-service.sock"
 
 GITHUB_REPO="patrickjaja/claude-cowork-service"
-GITHUB_API="https://api.github.com/repos/$GITHUB_REPO/releases/latest"
+# Pin to a specific release tag for reproducibility and security.
+# Update this when upgrading to a new version.
+PINNED_VERSION="${COWORK_SERVICE_VERSION:-v0.1.0}"
+GITHUB_API="https://api.github.com/repos/$GITHUB_REPO/releases/tags/$PINNED_VERSION"
+
+# Set SKIP_CHECKSUM_VERIFY=1 to allow installation without a .sha256 file
+# (not recommended — only use for testing unreleased builds).
+SKIP_CHECKSUM_VERIFY="${SKIP_CHECKSUM_VERIFY:-}"
 
 # ---------------------------------------------------------------------------
 # Dependency checks
@@ -82,7 +89,7 @@ log "Detected architecture: $ARCH ($ARCH_SUFFIX)"
 # ---------------------------------------------------------------------------
 # Fetch latest release info
 # ---------------------------------------------------------------------------
-log "Fetching latest release from $GITHUB_REPO..."
+log "Fetching release $PINNED_VERSION from $GITHUB_REPO..."
 
 RELEASE_JSON=""
 if [[ "$DOWNLOADER" == "curl" ]]; then
@@ -199,8 +206,14 @@ if [[ -n "$SHA256_URL" ]]; then
   fi
   log "SHA256 verified: $ACTUAL_SHA256"
 else
-  log "WARNING: No .sha256 file found in release. Recording checksum for audit."
-  log "SHA256: $ACTUAL_SHA256"
+  if [[ "$SKIP_CHECKSUM_VERIFY" == "1" ]]; then
+    log "WARNING: No .sha256 file found in release. SKIP_CHECKSUM_VERIFY=1, continuing anyway."
+    log "SHA256: $ACTUAL_SHA256"
+  else
+    log "ERROR: No .sha256 file found in release. Refusing to install unverified binary."
+    log "  Set SKIP_CHECKSUM_VERIFY=1 to override (not recommended)."
+    exit 1
+  fi
 fi
 
 # Store checksum alongside binary

--- a/scripts/validate-bundle.sh
+++ b/scripts/validate-bundle.sh
@@ -106,13 +106,44 @@ while IFS= read -r -d '' js_file; do
 done < <(find "$VITE_BUILD_DIR" -type f \( -name '*.js' -o -name '*.mjs' \) -print0)
 
 # ---------------------------------------------------------------------------
-# Validate native module stubs
+# Validate native module stubs (using acorn for consistency with bundle checks)
 # ---------------------------------------------------------------------------
 for stub_file in "$APP_DIR/node_modules/@ant/claude-native/index.js" \
                  "$APP_DIR/node_modules/@ant/claude-swift/index.js"; do
   [[ -f "$stub_file" ]] || continue
   CHECKED=$((CHECKED + 1))
-  if ! node -c "$stub_file" 2>/dev/null; then
+  if ! (
+    cd "$REPO_DIR" &&
+    node -e "
+      const acorn = require('acorn');
+      const fs = require('fs');
+      const path = require('path');
+      const file = process.argv[1];
+      const src = fs.readFileSync(file, 'utf8');
+      try {
+        acorn.parse(src, {
+          ecmaVersion: 'latest',
+          sourceType: 'module',
+          allowHashBang: true,
+          allowReturnOutsideFunction: true,
+        });
+      } catch (e1) {
+        try {
+          acorn.parse(src, {
+            ecmaVersion: 'latest',
+            sourceType: 'script',
+            allowHashBang: true,
+            allowReturnOutsideFunction: true,
+          });
+        } catch (e2) {
+          console.error('SYNTAX ERROR in ' + path.basename(file) + ':');
+          console.error('  ' + e2.message);
+          console.error('  at byte offset ' + (e2.pos || 'unknown'));
+          process.exit(1);
+        }
+      }
+    " "$stub_file"
+  ) 2>&1; then
     log "FAIL: stub $(basename "$(dirname "$stub_file")")/index.js has syntax errors"
     FAILED=1
   fi

--- a/stubs/claude-swift.js
+++ b/stubs/claude-swift.js
@@ -313,14 +313,16 @@ const _vmBase = {
    * Stop the VM — on Linux, kill all tracked child processes and reset state.
    */
   stopVM() {
-    for (const [pid, child] of _procs) {
+    // Snapshot PIDs before clearing so callbacks fire with correct data.
+    const entries = [..._procs.entries()];
+    _procs.clear();
+    for (const [pid, child] of entries) {
       try { child.kill('SIGTERM'); } catch {}
-      // Fire per-child onExit with consistent signature
       if (typeof _callbacks.onExit === 'function') {
-        setImmediate(() => _callbacks.onExit(pid, null, 'SIGTERM'));
+        const cbPid = pid;
+        process.nextTick(() => _callbacks.onExit(cbPid, null, 'SIGTERM'));
       }
     }
-    _procs.clear();
   },
 
   /**


### PR DESCRIPTION
Add support for Cowork and Dispatch features on Linux by integrating
the claude-cowork-service daemon and adding AST-based patches for
socket transport, GrowthBook feature flags, and ComputerUseTcc stubs.

New files:
- scripts/install-cowork-service.sh: downloads and installs the Go
  daemon from patrickjaja/claude-cowork-service as a systemd user
  service
- patches/patch-cowork-socket.mjs: rewrites Windows named pipe path
  to Linux Unix domain socket
- patches/patch-dispatch.mjs: force-enables GrowthBook feature flags
  (sessions-bridge, remote session control, hostLoopMode, platform
  label) required for Dispatch
- patches/patch-computer-use-tcc.mjs: injects ComputerUseTcc IPC
  handler stubs directly into the main bundle

Updated:
- scripts/patch-cowork.sh: wires new patches into build pipeline
- Launcher scripts: warn if cowork service not running
- Packaging: add cowork-svc-linux as optional dependency
- Documentation: Socket IPC protocol, Dispatch on Linux architecture

https://claude.ai/code/session_01FkEAY5ZiBbAUFnjr5zLTUS