### PR TITLE
fix(path-translator): gate aggressive monkey-patches behind env var to fix dev-channel crash

### DIFF
--- a/patches/path-translator.mjs
+++ b/patches/path-translator.mjs
@@ -13,7 +13,24 @@
  * symlink on the root filesystem.  All path translation happens in-process by
  * monkey-patching Node.js built-in modules (fs, path, child_process, net).
  *
- * Set COWORK_DEBUG=1 to log every translated path to stderr.
+ * Env vars:
+ *   COWORK_DEBUG=1                    — log every translated path to stderr
+ *   CLAUDE_EXTENDED_PATH_TRANSLATION=1
+ *                                     — enable the aggressive monkey-patch set
+ *                                       (path.normalize, fs sync/callback
+ *                                       methods, child_process spawn/execFile/
+ *                                       exec, net.connect/createConnection).
+ *                                       Off by default because at least one of
+ *                                       these wrappers was correlated with a
+ *                                       pre-main.js SIGSEGV on dev-channel
+ *                                       builds built against upstream
+ *                                       Claude Desktop 1.1617.0+.  With this
+ *                                       flag unset we fall back to the core
+ *                                       wrapping set (path.join, path.resolve,
+ *                                       fs.promises open/readFile/writeFile/
+ *                                       stat/readdir, fs.realpath*,
+ *                                       fs.createReadStream/WriteStream) that
+ *                                       matches the stable channel on main.
  */
 
 import path from 'path';
@@ -32,7 +49,11 @@ const TRANSLATE_SYM = Symbol.for('__claudeTranslatePath');
 if (!global[INIT_SYM] && process.type === 'browser') {
   global[INIT_SYM] = true;
 
-  const DEBUG = process.env.COWORK_DEBUG === '1';
+  const DEBUG    = process.env.COWORK_DEBUG === '1';
+  // Gate the aggressive monkey-patch set. See the header comment and
+  // https://github.com/stslex/claude-desktop-linux/pull/... for why this
+  // defaults off on dev-channel builds.
+  const EXTENDED = process.env.CLAUDE_EXTENDED_PATH_TRANSLATION === '1';
 
   // -------------------------------------------------------------------------
   // Session base directory
@@ -82,90 +103,22 @@ if (!global[INIT_SYM] && process.type === 'browser') {
   global[TRANSLATE_SYM] = translatePath;
 
   // -------------------------------------------------------------------------
-  // Monkey-patch path.join, path.resolve, path.normalize
+  // CORE SET — always active.  This matches the subset on the stable
+  // channel (main branch) that is known to not break Electron startup.
   // -------------------------------------------------------------------------
-  path.join      = (...segments) => translatePath(_origJoin(...segments));
-  path.resolve   = (...segments) => translatePath(_origResolve(...segments));
 
-  const _origNormalize = path.normalize.bind(path);
-  path.normalize = (p) => translatePath(_origNormalize(p));
+  // path.join, path.resolve
+  path.join    = (...segments) => translatePath(_origJoin(...segments));
+  path.resolve = (...segments) => translatePath(_origResolve(...segments));
 
-  // -------------------------------------------------------------------------
-  // Monkey-patch fs.promises methods (first-arg is a path)
-  // -------------------------------------------------------------------------
-  const FS_PROMISES_SINGLE_PATH = [
-    'open', 'readFile', 'writeFile', 'stat', 'lstat', 'readdir',
-    'access', 'mkdir', 'unlink', 'rm', 'chmod', 'chown',
-    'truncate', 'utimes', 'appendFile', 'realpath',
-  ];
-
-  for (const method of FS_PROMISES_SINGLE_PATH) {
+  // fs.promises: open / readFile / writeFile / stat / readdir
+  for (const method of ['open', 'readFile', 'writeFile', 'stat', 'readdir']) {
     if (typeof fs.promises[method] !== 'function') continue;
     const _orig = fs.promises[method].bind(fs.promises);
     fs.promises[method] = (p, ...rest) => _orig(translatePath(p), ...rest);
   }
 
-  // fs.promises methods with TWO path args
-  const FS_PROMISES_DUAL_PATH = ['copyFile', 'rename', 'symlink', 'link'];
-  for (const method of FS_PROMISES_DUAL_PATH) {
-    if (typeof fs.promises[method] !== 'function') continue;
-    const _orig = fs.promises[method].bind(fs.promises);
-    fs.promises[method] = (p1, p2, ...rest) =>
-      _orig(translatePath(p1), translatePath(p2), ...rest);
-  }
-
-  // -------------------------------------------------------------------------
-  // Monkey-patch fs sync methods (first-arg is a path)
-  // -------------------------------------------------------------------------
-  const FS_SYNC_SINGLE_PATH = [
-    'readFileSync', 'writeFileSync', 'openSync', 'statSync', 'lstatSync',
-    'readdirSync', 'accessSync', 'mkdirSync', 'unlinkSync', 'rmSync',
-    'chmodSync', 'chownSync', 'truncateSync', 'utimesSync', 'appendFileSync',
-    'existsSync',
-  ];
-
-  for (const method of FS_SYNC_SINGLE_PATH) {
-    if (typeof fs[method] !== 'function') continue;
-    const _orig = fs[method].bind(fs);
-    fs[method] = (p, ...rest) => _orig(translatePath(p), ...rest);
-  }
-
-  // fs sync methods with TWO path args
-  const FS_SYNC_DUAL_PATH = ['copyFileSync', 'renameSync', 'symlinkSync', 'linkSync'];
-  for (const method of FS_SYNC_DUAL_PATH) {
-    if (typeof fs[method] !== 'function') continue;
-    const _orig = fs[method].bind(fs);
-    fs[method] = (p1, p2, ...rest) =>
-      _orig(translatePath(p1), translatePath(p2), ...rest);
-  }
-
-  // -------------------------------------------------------------------------
-  // Monkey-patch fs callback methods (first-arg is a path)
-  // -------------------------------------------------------------------------
-  const FS_CB_SINGLE_PATH = [
-    'open', 'readFile', 'writeFile', 'stat', 'lstat', 'readdir',
-    'access', 'mkdir', 'unlink', 'rm', 'chmod', 'chown',
-    'truncate', 'utimes', 'appendFile',
-  ];
-
-  for (const method of FS_CB_SINGLE_PATH) {
-    if (typeof fs[method] !== 'function') continue;
-    const _orig = fs[method].bind(fs);
-    fs[method] = (p, ...rest) => _orig(translatePath(p), ...rest);
-  }
-
-  // fs callback methods with TWO path args
-  const FS_CB_DUAL_PATH = ['copyFile', 'rename', 'symlink', 'link'];
-  for (const method of FS_CB_DUAL_PATH) {
-    if (typeof fs[method] !== 'function') continue;
-    const _orig = fs[method].bind(fs);
-    fs[method] = (p1, p2, ...rest) =>
-      _orig(translatePath(p1), translatePath(p2), ...rest);
-  }
-
-  // -------------------------------------------------------------------------
-  // Monkey-patch fs.realpath / fs.realpathSync (+ .native variants)
-  // -------------------------------------------------------------------------
+  // fs.realpath / fs.realpathSync (+ .native variants)
   if (typeof fs.realpathSync === 'function') {
     const _origSync = fs.realpathSync.bind(fs);
     const _origNative = typeof fs.realpathSync.native === 'function'
@@ -188,9 +141,7 @@ if (!global[INIT_SYM] && process.type === 'browser') {
     }
   }
 
-  // -------------------------------------------------------------------------
-  // Monkey-patch fs.createReadStream / fs.createWriteStream
-  // -------------------------------------------------------------------------
+  // fs.createReadStream / fs.createWriteStream
   if (typeof fs.createReadStream === 'function') {
     const _orig = fs.createReadStream.bind(fs);
     fs.createReadStream = (p, ...rest) =>
@@ -204,112 +155,185 @@ if (!global[INIT_SYM] && process.type === 'browser') {
   }
 
   // -------------------------------------------------------------------------
-  // Monkey-patch child_process.spawn / execFile / exec
-  // Translate cwd option and any string args containing /sessions/ paths.
+  // EXTENDED SET — opt-in via CLAUDE_EXTENDED_PATH_TRANSLATION=1.
+  //
+  // These wrappers cover more of the Node.js path surface (path.normalize,
+  // all fs sync/callback methods, dual-path fs methods, child_process,
+  // net).  They are correlated with a pre-main.js SIGSEGV on dev-channel
+  // builds built against upstream Claude Desktop 1.1617.0+ — the main
+  // process crashes during Chromium's DBus init before any JS log line
+  // is flushed.  Root cause not yet confirmed; possible culprits include
+  // net.connect/createConnection wrapping (which Electron uses internally
+  // for main↔renderer IPC) and child_process.spawn wrapping (which
+  // changes the overloaded signature handling in subtle ways).
+  //
+  // When this flag is off we preserve the CORE SET above, which matches
+  // the main-branch behaviour that is known-good in the stable channel.
+  // Users who need /sessions path translation in more places can opt in
+  // via `CLAUDE_EXTENDED_PATH_TRANSLATION=1 claude-desktop` after we
+  // identify and fix the specific wrapper that breaks.
   // -------------------------------------------------------------------------
-  function translateSpawnArgs(command, argsOrOpts, opts) {
-    // Normalize the overloaded signatures:
-    //   spawn(cmd, args, opts)  or  spawn(cmd, opts)
-    let args, options;
-    if (Array.isArray(argsOrOpts)) {
-      args = argsOrOpts;
-      options = opts || {};
-    } else if (argsOrOpts && typeof argsOrOpts === 'object') {
-      args = undefined;
-      options = argsOrOpts;
-    } else {
-      args = argsOrOpts;
-      options = opts || {};
+  if (EXTENDED) {
+    process.stderr.write(
+      '[path-translator] CLAUDE_EXTENDED_PATH_TRANSLATION=1 — enabling ' +
+      'aggressive monkey-patch set (experimental).\n'
+    );
+
+    // path.normalize
+    const _origNormalize = path.normalize.bind(path);
+    path.normalize = (p) => translatePath(_origNormalize(p));
+
+    // Expanded fs.promises single-path set
+    const FS_PROMISES_EXTENDED = [
+      'lstat', 'access', 'mkdir', 'unlink', 'rm', 'chmod', 'chown',
+      'truncate', 'utimes', 'appendFile', 'realpath',
+    ];
+    for (const method of FS_PROMISES_EXTENDED) {
+      if (typeof fs.promises[method] !== 'function') continue;
+      const _orig = fs.promises[method].bind(fs.promises);
+      fs.promises[method] = (p, ...rest) => _orig(translatePath(p), ...rest);
     }
 
-    // Translate cwd
-    if (options && typeof options.cwd === 'string') {
-      const translated = translatePath(options.cwd);
-      if (translated !== options.cwd) {
-        options = { ...options, cwd: translated };
+    // fs.promises dual-path
+    const FS_PROMISES_DUAL_PATH = ['copyFile', 'rename', 'symlink', 'link'];
+    for (const method of FS_PROMISES_DUAL_PATH) {
+      if (typeof fs.promises[method] !== 'function') continue;
+      const _orig = fs.promises[method].bind(fs.promises);
+      fs.promises[method] = (p1, p2, ...rest) =>
+        _orig(translatePath(p1), translatePath(p2), ...rest);
+    }
+
+    // fs sync single-path
+    const FS_SYNC_SINGLE_PATH = [
+      'readFileSync', 'writeFileSync', 'openSync', 'statSync', 'lstatSync',
+      'readdirSync', 'accessSync', 'mkdirSync', 'unlinkSync', 'rmSync',
+      'chmodSync', 'chownSync', 'truncateSync', 'utimesSync', 'appendFileSync',
+      'existsSync',
+    ];
+    for (const method of FS_SYNC_SINGLE_PATH) {
+      if (typeof fs[method] !== 'function') continue;
+      const _orig = fs[method].bind(fs);
+      fs[method] = (p, ...rest) => _orig(translatePath(p), ...rest);
+    }
+
+    // fs sync dual-path
+    const FS_SYNC_DUAL_PATH = ['copyFileSync', 'renameSync', 'symlinkSync', 'linkSync'];
+    for (const method of FS_SYNC_DUAL_PATH) {
+      if (typeof fs[method] !== 'function') continue;
+      const _orig = fs[method].bind(fs);
+      fs[method] = (p1, p2, ...rest) =>
+        _orig(translatePath(p1), translatePath(p2), ...rest);
+    }
+
+    // fs callback single-path
+    const FS_CB_SINGLE_PATH = [
+      'open', 'readFile', 'writeFile', 'stat', 'lstat', 'readdir',
+      'access', 'mkdir', 'unlink', 'rm', 'chmod', 'chown',
+      'truncate', 'utimes', 'appendFile',
+    ];
+    for (const method of FS_CB_SINGLE_PATH) {
+      if (typeof fs[method] !== 'function') continue;
+      const _orig = fs[method].bind(fs);
+      fs[method] = (p, ...rest) => _orig(translatePath(p), ...rest);
+    }
+
+    // fs callback dual-path
+    const FS_CB_DUAL_PATH = ['copyFile', 'rename', 'symlink', 'link'];
+    for (const method of FS_CB_DUAL_PATH) {
+      if (typeof fs[method] !== 'function') continue;
+      const _orig = fs[method].bind(fs);
+      fs[method] = (p1, p2, ...rest) =>
+        _orig(translatePath(p1), translatePath(p2), ...rest);
+    }
+
+    // child_process.spawn / execFile / exec
+    function translateSpawnArgs(command, argsOrOpts, opts) {
+      let args, options;
+      if (Array.isArray(argsOrOpts)) {
+        args = argsOrOpts;
+        options = opts || {};
+      } else if (argsOrOpts && typeof argsOrOpts === 'object') {
+        args = undefined;
+        options = argsOrOpts;
+      } else {
+        args = argsOrOpts;
+        options = opts || {};
       }
-    }
 
-    // Translate string args containing /sessions/
-    if (Array.isArray(args)) {
-      const newArgs = args.map(a => (typeof a === 'string' ? translatePath(a) : a));
-      const changed = newArgs.some((a, i) => a !== args[i]);
-      if (changed) args = newArgs;
-    }
-
-    // Translate command if it contains /sessions/
-    command = translatePath(command);
-
-    return { command, args, options };
-  }
-
-  const _origSpawn = child_process.spawn.bind(child_process);
-  child_process.spawn = (cmd, argsOrOpts, opts) => {
-    const t = translateSpawnArgs(cmd, argsOrOpts, opts);
-    return t.args !== undefined
-      ? _origSpawn(t.command, t.args, t.options)
-      : _origSpawn(t.command, t.options);
-  };
-
-  const _origExecFile = child_process.execFile.bind(child_process);
-  child_process.execFile = (cmd, argsOrOpts, opts, cb) => {
-    // execFile has signature: (file, args?, options?, callback?)
-    // Detect which form is used
-    if (typeof argsOrOpts === 'function') {
-      return _origExecFile(translatePath(cmd), argsOrOpts);
-    }
-    if (typeof opts === 'function') {
-      const t = translateSpawnArgs(cmd, argsOrOpts, {});
-      return t.args !== undefined
-        ? _origExecFile(t.command, t.args, opts)
-        : _origExecFile(t.command, t.options, opts);
-    }
-    const t = translateSpawnArgs(cmd, argsOrOpts, opts);
-    return t.args !== undefined
-      ? _origExecFile(t.command, t.args, t.options, cb)
-      : _origExecFile(t.command, t.options, cb);
-  };
-
-  const _origExec = child_process.exec.bind(child_process);
-  child_process.exec = (cmd, ...rest) => {
-    // exec takes a command string — translate any /sessions/ paths in it.
-    // We handle both unquoted and quoted paths:
-    //   unquoted: /sessions/uuid/mnt/name/file.txt  (stop at whitespace or shell metachar)
-    //   single-quoted: '/sessions/uuid/mnt/name/file with spaces.txt'
-    //   double-quoted: "/sessions/uuid/mnt/name/file with spaces.txt"
-    if (typeof cmd === 'string') {
-      cmd = cmd
-        // Single-quoted paths: translate content, re-wrap in single quotes
-        .replace(/'(\/sessions\/[^']+)'/g, (_m, p) => `'${translatePath(p)}'`)
-        // Double-quoted paths: translate content, re-wrap in double quotes
-        .replace(/"(\/sessions\/[^"]+)"/g, (_m, p) => `"${translatePath(p)}"`)
-        // Unquoted paths: stop at whitespace, quotes, or common shell metacharacters
-        .replace(/(?<=['"\s]|^)(\/sessions\/[^\s'";&|<>()]+)/g, (_m, p) => translatePath(p));
-    }
-    return _origExec(cmd, ...rest);
-  };
-
-  // -------------------------------------------------------------------------
-  // Monkey-patch net.connect / net.createConnection for socket paths
-  // -------------------------------------------------------------------------
-  function wrapNetConnect(orig) {
-    return function (optionsOrPath, ...rest) {
-      if (typeof optionsOrPath === 'string') {
-        return orig.call(this, translatePath(optionsOrPath), ...rest);
-      }
-      if (optionsOrPath && typeof optionsOrPath === 'object' &&
-          typeof optionsOrPath.path === 'string') {
-        const translated = translatePath(optionsOrPath.path);
-        if (translated !== optionsOrPath.path) {
-          optionsOrPath = { ...optionsOrPath, path: translated };
+      if (options && typeof options.cwd === 'string') {
+        const translated = translatePath(options.cwd);
+        if (translated !== options.cwd) {
+          options = { ...options, cwd: translated };
         }
       }
-      return orig.call(this, optionsOrPath, ...rest);
-    };
-  }
 
-  net.connect          = wrapNetConnect(net.connect.bind(net));
-  net.createConnection = wrapNetConnect(net.createConnection.bind(net));
+      if (Array.isArray(args)) {
+        const newArgs = args.map(a => (typeof a === 'string' ? translatePath(a) : a));
+        const changed = newArgs.some((a, i) => a !== args[i]);
+        if (changed) args = newArgs;
+      }
+
+      command = translatePath(command);
+
+      return { command, args, options };
+    }
+
+    const _origSpawn = child_process.spawn.bind(child_process);
+    child_process.spawn = (cmd, argsOrOpts, opts) => {
+      const t = translateSpawnArgs(cmd, argsOrOpts, opts);
+      return t.args !== undefined
+        ? _origSpawn(t.command, t.args, t.options)
+        : _origSpawn(t.command, t.options);
+    };
+
+    const _origExecFile = child_process.execFile.bind(child_process);
+    child_process.execFile = (cmd, argsOrOpts, opts, cb) => {
+      if (typeof argsOrOpts === 'function') {
+        return _origExecFile(translatePath(cmd), argsOrOpts);
+      }
+      if (typeof opts === 'function') {
+        const t = translateSpawnArgs(cmd, argsOrOpts, {});
+        return t.args !== undefined
+          ? _origExecFile(t.command, t.args, opts)
+          : _origExecFile(t.command, t.options, opts);
+      }
+      const t = translateSpawnArgs(cmd, argsOrOpts, opts);
+      return t.args !== undefined
+        ? _origExecFile(t.command, t.args, t.options, cb)
+        : _origExecFile(t.command, t.options, cb);
+    };
+
+    const _origExec = child_process.exec.bind(child_process);
+    child_process.exec = (cmd, ...rest) => {
+      if (typeof cmd === 'string') {
+        cmd = cmd
+          .replace(/'(\/sessions\/[^']+)'/g, (_m, p) => `'${translatePath(p)}'`)
+          .replace(/"(\/sessions\/[^"]+)"/g, (_m, p) => `"${translatePath(p)}"`)
+          .replace(/(?<=['"\s]|^)(\/sessions\/[^\s'";&|<>()]+)/g, (_m, p) => translatePath(p));
+      }
+      return _origExec(cmd, ...rest);
+    };
+
+    // net.connect / net.createConnection
+    function wrapNetConnect(orig) {
+      return function (optionsOrPath, ...rest) {
+        if (typeof optionsOrPath === 'string') {
+          return orig.call(this, translatePath(optionsOrPath), ...rest);
+        }
+        if (optionsOrPath && typeof optionsOrPath === 'object' &&
+            typeof optionsOrPath.path === 'string') {
+          const translated = translatePath(optionsOrPath.path);
+          if (translated !== optionsOrPath.path) {
+            optionsOrPath = { ...optionsOrPath, path: translated };
+          }
+        }
+        return orig.call(this, optionsOrPath, ...rest);
+      };
+    }
+
+    net.connect          = wrapNetConnect(net.connect.bind(net));
+    net.createConnection = wrapNetConnect(net.createConnection.bind(net));
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## The bug

Dev-channel builds (RPM on Fedora + Nix on NixOS) segfault on launch
immediately after Chromium's DBus init, before any JS log line from
our prepended patches is flushed:

```
[16291:0411/165820:INFO:...cpu_info.cc:75] Available number of cores: 32
[16292:0411/165820:INFO:...cpu_info.cc:75] Available number of cores: 32
[16292:0411/165820:VERBOSE1:...zygote_main_linux.cc:201] ZygoteMain: initializing 0 fork delegates
[16291:0411/165820:VERBOSE1:...zygote_main_linux.cc:201] ZygoteMain: initializing 0 fork delegates
[16283:0411/165820:VERBOSE1:dbus/bus.cc:916] Method call: ... GetNameOwner ... "org.freedesktop.login1"
[1]    16283 segmentation fault (core dumped)
```

Stable-channel builds from `main` (`v1.569.0-repack-6`) do not exhibit
this. Both channels use identical bundled Electron (40.8.5) and go
through identical `inject-stubs.sh` + `patch-cowork.sh` pipelines, so
the delta has to be in the handful of runtime-affecting files that
changed on dev after the merge base at `561dd57`:

- `patches/path-translator.mjs` ← +219 lines
- `stubs/claude-swift.js` ← +49 lines (method + getter additions)
- `scripts/patch-cowork.sh` ← adds gated experimental patches + validation

Two things narrow the suspect list further:

1. **The user's log has NO JS output.** `module-load-patch.js` writes
   `[module-load-patch] Shared Module._load override installed.` to
   stderr on init, and the user's `--enable-logging=stderr --v=1`
   capture does not contain it. That places the crash *before*
   `main.js` runs — which means the only suspect is code that
   executes during Chromium's native init, but whose *side effects*
   persist into the patched bundle.

2. **`path-translator.mjs` runs at the very top of the patched
   bundle** (it's `require()`d first via the prepend in
   `patch-cowork.sh`). If Electron's native init later dispatches
   into any V8 callback that touches the monkey-patched surface —
   internal IPC via `net.connect`, subprocess spawning via
   `child_process.spawn`, or synchronous fs access — the mismatched
   wrapper shape can propagate back into native code and crash it.

Of the dev-only changes, path-translator is the only one that
executes at main-process startup before Electron's native DBus init
via the prepended `require('./path-translator.js')`. That puts it at
the top of the suspect list.

## The change

Split the monkey-patch set into two tiers:

**Core set** (always active — matches `main` branch exactly):

- `path.join`, `path.resolve`
- `fs.promises.{open, readFile, writeFile, stat, readdir}`
- `fs.realpath` / `fs.realpathSync` (+ `.native` variants)
- `fs.createReadStream` / `fs.createWriteStream`

**Extended set** (opt-in via `CLAUDE_EXTENDED_PATH_TRANSLATION=1`):

- `path.normalize`
- Expanded `fs.promises` single-path (lstat, access, mkdir, unlink,
  rm, chmod, chown, truncate, utimes, appendFile, realpath)
- `fs.promises` dual-path (copyFile, rename, symlink, link)
- `fs.*Sync` single-path + dual-path
- `fs.*` callback single-path + dual-path
- `child_process.spawn` / `execFile` / `exec`
- `net.connect` / `net.createConnection`

The Core set is the exact subset that has been shipping on `main` for
months and is known to coexist with Electron's native startup. The
Extended set was added in `32ba4a6 fix: remove /sessions root symlink
dependency for immutable distros` and correlates timewise with the
dev-channel crash.

At least one wrapper in the Extended set is the proximate cause. Most
likely candidates in rough probability order:

1. **`net.connect` / `net.createConnection`** — Electron uses
   internal Unix socket IPC for main↔renderer that goes through the
   same `net` surface. The spread-and-rebuild of the options object
   in `wrapNetConnect` changes object identity in a way that could
   confuse V8 hidden-class optimisations on the hot IPC path.
2. **`child_process.spawn`** — the signature-overload normalisation
   in `translateSpawnArgs` changes the default `options` from
   `undefined` to `{}` in the 1-arg case. Subtle, but observable by
   native callers that inspect the options shape.
3. Any of the `fs.*Sync` wrappers, if Electron's native init does a
   synchronous read through V8 during startup.

Defaulting the Extended set off restores `main`'s behaviour as the
safe path until we bisect the specific wrapper.

## How this interacts with the motivating feature

Commit `32ba4a6` removed a `/sessions` root-filesystem symlink
dependency by translating `/sessions/<uuid>/mnt/<mount>/...` paths
in-process. The Core set — already on `main` — covers the common
path operations the app actually uses: `path.join`, `path.resolve`,
async fs APIs via `fs.promises`, realpath, and stream creation. In
spot checks, `claude-code` and the renderer do not reach for
`fs.*Sync` with a `/sessions/` path during normal use; sync methods
matter primarily for the patched bundle download helper, which runs
later and can be opted into via the env var.

Users who need `/sessions` translation in more places can opt in
with `CLAUDE_EXTENDED_PATH_TRANSLATION=1 claude-desktop` until we
ship a proper root-cause fix.

## Test plan

- [x] Diff reviewed — Core set matches `main` byte-for-byte; Extended
      set is preserved verbatim, just inside the `if (EXTENDED) {}`
      block.
- [x] Imports for `child_process` and `net` kept at top-level so the
      sed-based ESM→CJS conversion in `patch-cowork.sh:454` still
      matches its expected line patterns. (Loading a built-in module
      has no side effects — this just makes it available if someone
      opts in to the Extended set.)
- [ ] **User verifies on Fedora + NixOS**: after this merges into
      `dev` and CI publishes `v1.1617.0-dev.*` with the updated
      bundle, launch `claude-desktop` without `CLAUDE_EXTENDED_PATH_TRANSLATION`
      set. Expected: no more pre-main.js SIGSEGV, app either opens
      normally or fails later with a *different* symptom that we can
      iterate on.
- [ ] If the crash persists after this merges, the hypothesis was
      wrong and path-translator is innocent. Next step is to add
      `process.stderr.write()` breadcrumbs at the top of
      `module-load-patch.js` / `shell-env-patch.js` / etc. to see
      which prepended file the crash happens after (or whether any
      of them run at all).

## What this does NOT fix

- PR #61's `buildInputs` additions (`systemd`, `libglvnd`,
  `libsecret`, `libpulseaudio`, `libnotify`, `fontconfig`, `freetype`)
  were a wrong guess based on the misleading "crashed after DBus
  call to logind" symptom. The crash is on Fedora too (where
  `libsystemd.so.0` is in `/usr/lib` and the non-Nix dynamic linker
  finds it without help), so the real cause is not a Nix-specific
  missing library. The PR #61 changes are still correct in
  principle — nixpkgs/chromium pins the same set for the same reason
  — but they are not the fix for this user's crash. Leaving them in
  as a defensive NixOS improvement.

https://claude.ai/code/session_01SYHQXaS8AN4tQFh9EM9eLm