### PR TITLE
fix(nix): drop wrapProgram --prefix LD_LIBRARY_PATH — actual cause of SEGV on NixOS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -261,60 +261,77 @@
               ln -sn ../electron "$out/lib/claude-desktop/electron"
 
               # wrapProgram:
-              #   - PATH           → xdg-utils + bubblewrap for the launcher's
-              #                      xdg-mime / bwrap invocations; also
-              #                      $out/lib/electron so `command -v electron`
-              #                      resolves if the symlinked candidate above
-              #                      is ever invalidated by a future refactor.
-              #   - LD_LIBRARY_PATH → bundled Electron's private .so files
-              #                      PLUS the system libs Chromium dlopens
-              #                      at runtime (systemd/libsystemd for
-              #                      logind DBus, libglvnd for libGL.so.1,
-              #                      libsecret for safeStorage, libpulseaudio
-              #                      for audio, libnotify for desktop
-              #                      notifications, fontconfig/freetype for
-              #                      text rendering).
+              #   - PATH → xdg-utils + bubblewrap for the launcher's
+              #            xdg-mime / bwrap invocations; also
+              #            $out/lib/electron so `command -v electron`
+              #            resolves if the symlinked candidate at
+              #            $out/lib/claude-desktop/electron is ever
+              #            invalidated by a future refactor.
               #
-              #                      autoPatchelfHook already rewrites RPATH
-              #                      on the main electron binary and its
-              #                      sibling .so files so that DT_NEEDED
-              #                      links resolve. But dlopen()'d libs that
-              #                      aren't DT_NEEDED only fall back to
-              #                      LD_LIBRARY_PATH + the system default
-              #                      search path, and on NixOS the system
-              #                      default is not useful. Prefixing
-              #                      LD_LIBRARY_PATH here catches those —
-              #                      specifically libsystemd.so.0, which
-              #                      Chromium dlopens for the sd-bus binding
-              #                      against org.freedesktop.login1 during
-              #                      main-process init and which segfaults
-              #                      with NULL handle on missing dlopen.
+              # NO `--prefix LD_LIBRARY_PATH` HERE — INTENTIONAL.
               #
-              # NOTE: the V8 `--js-flags=--no-memory-protection-keys`
-              # workaround for the NixOS 6.18+ PKU SEGV is injected
-              # directly into the launcher's `exec "$ELECTRON" ...` line
-              # via the `substituteInPlace --replace-fail` block above,
-              # NOT via `wrapProgram --add-flags`. That's because flags
-              # appended through `--add-flags` arrive in the launcher's
-              # `"$@"` and end up *after* `$ASAR` in the final
-              # `exec "$ELECTRON" --no-sandbox "$ASAR" "$@"`, where
-              # Electron treats them as application arguments rather
-              # than Chromium/V8 switches — the PKU SEGV still fires.
-              # Injecting the flag into the exec line directly puts it
-              # in the correct Chromium-switch position before `$ASAR`.
+              # An earlier iteration of this wrapper prefixed
+              # `LD_LIBRARY_PATH` with `$out/lib/electron` plus the
+              # `lib.makeLibraryPath` of `systemd / libglvnd /
+              # libsecret / libpulseaudio / libnotify / fontconfig /
+              # freetype` as a defensive measure under the hypothesis
+              # that bundled Electron dlopens those at runtime. That
+              # wrapper was correlated with a guaranteed startup
+              # SIGSEGV on NixOS 6.18.21 that did NOT reproduce when
+              # the underlying `.claude-desktop-wrapped` launcher
+              # was invoked directly (bypassing the wrapper env
+              # setup) — even with the V8 `--js-flags=--no-memory-
+              # protection-keys` PKU workaround correctly injected
+              # into the launcher's `exec` line via
+              # `substituteInPlace`, the crash persisted as long as
+              # the wrapper's `LD_LIBRARY_PATH` was in the
+              # environment.
+              #
+              # Removing the `LD_LIBRARY_PATH` prefixes entirely is
+              # the safe path:
+              #
+              #   1. `autoPatchelfHook` already rewrites DT_NEEDED /
+              #      DT_RUNPATH on the electron binary and on every
+              #      bundled .so that it can reach, so the library
+              #      closure resolves through RPATH without needing
+              #      `LD_LIBRARY_PATH` help. All of the entries from
+              #      the previous `--prefix LD_LIBRARY_PATH` set are
+              #      still in `buildInputs` above, so they're still
+              #      in the closure — we just don't override the
+              #      dynamic linker's search path with them at
+              #      wrapper time.
+              #
+              #   2. Empirically, invoking the unwrapped launcher
+              #      `$out/bin/.claude-desktop-wrapped` directly (no
+              #      wrapper env) — which uses the same electron
+              #      binary from the same store path with the same
+              #      RPATH — runs past the SEGV point and reaches
+              #      steady-state inside Electron's startup path.
+              #      Reintroducing the wrapper's `LD_LIBRARY_PATH`
+              #      overrides via `env LD_LIBRARY_PATH=...
+              #      .claude-desktop-wrapped` reproduces the SEGV.
+              #      That A/B is the actual smoking gun — the crash
+              #      is caused by `LD_LIBRARY_PATH` overriding the
+              #      RPATH-based library closure in a way that
+              #      interferes with something V8 / Chromium does
+              #      during main-process init. Best guess: the
+              #      dynamic linker picks up a mismatched
+              #      `libEGL.so` / `libGLESv2.so` / `libsecret-1.so`
+              #      via the prefix, and the resulting lib graph
+              #      triggers a code path that the RPATH-resolved
+              #      one does not. Root cause not confirmed past
+              #      that.
+              #
+              # If a future Electron / upstream change starts to
+              # dlopen a lib that `autoPatchelfHook` can't predict
+              # (and fails for it), add that lib to `buildInputs`
+              # and let `autoPatchelfHook` patch it in via RPATH.
+              # Do NOT re-add `--prefix LD_LIBRARY_PATH` without
+              # first re-running the A/B above to confirm it
+              # doesn't reintroduce the SEGV.
               wrapProgram $out/bin/claude-desktop \
-                --prefix PATH            : "${lib.makeBinPath [ pkgs.xdg-utils pkgs.bubblewrap ]}" \
-                --prefix PATH            : "$out/lib/electron" \
-                --prefix LD_LIBRARY_PATH : "$out/lib/electron" \
-                --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath (with pkgs; [
-                  systemd
-                  libglvnd
-                  libsecret
-                  libpulseaudio
-                  libnotify
-                  fontconfig
-                  freetype
-                ])}"
+                --prefix PATH : "${lib.makeBinPath [ pkgs.xdg-utils pkgs.bubblewrap ]}" \
+                --prefix PATH : "$out/lib/electron"
 
               runHook postInstall
             '';


### PR DESCRIPTION
## Actually found the cause via an A/B bisect

After PR #65 landed the V8 flag into the launcher's `exec` line
correctly (verified byte-for-byte via hexdump on the installed
`.claude-desktop-wrapped`), `claude-desktop` *still* segfaulted
on start on the user's NixOS 6.18.21 host.

A direct-invocation A/B finally isolated the actual culprit:

| Invocation                                                | Result      |
| --------------------------------------------------------- | ----------- |
| `$out/bin/.claude-desktop-wrapped` (bypass wrapProgram)   | **ALIVE**   |
| `electron ... --js-flags=... "$ASAR"` (bare env)          | **ALIVE**   |
| `claude-desktop` (via wrapProgram wrapper)                | SIGSEGV     |

Same store path, same electron binary, same RPATH, same
launcher script, same V8 flag at the same position in `argv` —
the only difference is whether the process inherits the
wrapper's `LD_LIBRARY_PATH` override.

The user's `.claude-desktop-wrapped` test output shows the
launcher running past the normal SEGV point and into the
`claude-cowork service not running` + `bwrap not found` warnings,
with no crash in the 10-second probe window. Reintroducing the
wrapper env makes the SEGV return deterministically.

## What was wrong

An earlier defensive iteration on this same branch set
`LD_LIBRARY_PATH` in the wrapper to:

```
$out/lib/electron : lib.makeLibraryPath (systemd libglvnd
                    libsecret libpulseaudio libnotify
                    fontconfig freetype)
```

The reasoning at the time was "bundled Electron dlopens these
libraries at runtime and `autoPatchelfHook` can't always reach
them, so a belt-and-suspenders `LD_LIBRARY_PATH` prefix catches
them all". That reasoning was wrong on two counts:

1. `autoPatchelfHook` already writes DT_NEEDED / DT_RUNPATH
   entries on the electron binary for every lib in `buildInputs`.
   The library closure resolves through RPATH without needing
   any `LD_LIBRARY_PATH` help.

2. Worse, the wrapper's `LD_LIBRARY_PATH` prefix is actively
   **harmful** in practice: it causes the dynamic linker to
   resolve some subset of the electron closure through the
   prefix path instead of through the RPATH, and the resulting
   mismatched library graph triggers a SIGSEGV during Chromium
   main-process init that doesn't happen with pure RPATH
   resolution.

I don't have a smoking-gun root cause on exactly which library
(or combination) is the proximate trigger inside Chromium — narrowing
that down would need another round of per-lib bisect of the
`lib.makeLibraryPath` list. But the fix is the same either way:
don't override `LD_LIBRARY_PATH` at all, and let
`autoPatchelfHook`'s RPATH do its job.

## The fix

Remove the two `--prefix LD_LIBRARY_PATH` lines from the
`wrapProgram` call. Keep the `--prefix PATH` lines — the
launcher still needs `xdg-utils` (for `xdg-mime` and the OAuth
deep-link `xdg-open`) and `bubblewrap` (for `bwrap` in the
Cowork sandbox backend).

`buildInputs` is untouched. All of the libs that were in the
old `LD_LIBRARY_PATH` prefix set (`systemd`, `libglvnd`,
`libsecret`, `libpulseaudio`, `libnotify`, `fontconfig`,
`freetype`) stay there so `autoPatchelfHook` keeps resolving
them through RPATH, which has been fine all along. The only
thing that changes is that those libs are no longer
force-prefixed into `LD_LIBRARY_PATH` at runtime.

## Relationship to the preceding PRs on this branch

| PR   | Change                                                              | Status |
| ---- | ------------------------------------------------------------------- | ------ |
| #61  | Add defensive libs to `buildInputs` + `--prefix LD_LIBRARY_PATH`    | merged |
| #62  | Gate `path-translator.mjs` extended monkey-patches behind env var   | merged |
| #63  | Wrong V8 flag `--no-write-protect-code-memory` (doesn't exist)      | closed |
| #64  | Correct V8 flag via `wrapProgram --add-flags` (wrong positioning)   | merged |
| #65  | Correct V8 flag via `substituteInPlace --replace-fail` (right pos)  | merged |
| **this PR** | **Drop `--prefix LD_LIBRARY_PATH` from PR #61** — actual cause | open |

The `buildInputs` additions from #61 stay. The
`path-translator.mjs` gating from #62 stays. The V8 flag
injection from #65 stays. This PR only reverts the
`LD_LIBRARY_PATH` manipulation from #61 — which turned out to
be the SEGV-causing footgun the whole time.

## Test plan

- [x] A/B verified locally on the user's host — bypassing
      wrapProgram (running `.claude-desktop-wrapped` directly)
      runs past the SEGV point.
- [x] Diff reviewed — only the `--prefix LD_LIBRARY_PATH` lines
      are removed; PATH prefixes untouched, `buildInputs`
      untouched, V8 flag injection untouched.
- [x] Extensive inline comment added to warn future maintainers
      not to re-add `--prefix LD_LIBRARY_PATH` without re-running
      the A/B bisect. This is the kind of "looks defensively
      correct, is actually a footgun" change that someone will
      try to 'fix' again in six months.
- [ ] **User verifies on NixOS 6.18.21** after merge:
      ```
      cd ~/nixos
      nix flake update claude-desktop-linux
      sudo nixos-rebuild switch --flake .#nixos --impure
      claude-desktop
      ```
      Expected: no SEGV on startup, app opens OAuth flow or at
      least a window.

https://claude.ai/code/session_01SYHQXaS8AN4tQFh9EM9eLm