### PR TITLE
fix(nix): expand $out at build time in PATH substituteInPlace

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -248,8 +248,8 @@
                   'exec "$ELECTRON" --no-sandbox --js-flags=--no-memory-protection-keys "$ASAR" "$@"' \
                 --replace-fail \
                   'set -euo pipefail' \
-                  'set -euo pipefail
-export PATH="${lib.makeBinPath [ pkgs.xdg-utils pkgs.bubblewrap ]}:$out/lib/electron:$PATH"'
+                  "set -euo pipefail
+export PATH=\"${lib.makeBinPath [ pkgs.xdg-utils pkgs.bubblewrap ]}:$out/lib/electron:\$PATH\""
 
               # The launcher's first electron-lookup candidate is
               # `$(dirname "$ASAR")/electron/electron`. After substitution


### PR DESCRIPTION
One-line fix: PR #67's `substituteInPlace` for the PATH export used single-quoted bash replacement, so `$out` was literal in the installed launcher → `set -u` crash: `out: unbound variable`.

Switch to double quotes so `$out` expands at build time. `\$PATH` keeps `$PATH` literal for runtime.

https://claude.ai/code/session_01SYHQXaS8AN4tQFh9EM9eLm