### PR TITLE
fix(nix): add --no-zygote so renderer children inherit V8 PKU workaround

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -245,7 +245,7 @@
                 --replace-quiet '/usr/lib/claude-desktop/ELECTRON_VERSION' "$out/lib/claude-desktop/ELECTRON_VERSION" \
                 --replace-fail \
                   'exec "$ELECTRON" --no-sandbox "$ASAR" "$@"' \
-                  'exec "$ELECTRON" --no-sandbox --js-flags=--no-memory-protection-keys "$ASAR" "$@"' \
+                  'exec "$ELECTRON" --no-sandbox --no-zygote --js-flags=--no-memory-protection-keys "$ASAR" "$@"' \
                 --replace-fail \
                   'set -euo pipefail' \
                   "set -euo pipefail


### PR DESCRIPTION
## Problem

After PRs #67 + #68 eliminated the wrapper SEGV and fixed the `$out` quoting, the process survives **20+ seconds** (the main process's `--js-flags=--no-memory-protection-keys` works). But then crashes at ~25s when a renderer's V8 starts JIT.

strace from an earlier run confirms zygote processes are exec'd **without** `--js-flags`:

```
execve(".../electron", ["...", "--type=zygote", "--no-sandbox"], ...)
```

When a renderer forks from the zygote, its V8 init doesn't know about `--no-memory-protection-keys` → uses PKU → SEGV_ACCERR ~20s in.

## Fix

Add `--no-zygote` to the `exec` line. This disables the pre-fork zygote server. All child processes are spawned fresh via fork+exec, and Chromium's `AppendExtraCommandLineSwitches` propagates `--js-flags` to each one's command line.

```diff
-exec "$ELECTRON" --no-sandbox --js-flags=--no-memory-protection-keys "$ASAR" "$@"
+exec "$ELECTRON" --no-sandbox --no-zygote --js-flags=--no-memory-protection-keys "$ASAR" "$@"
```

https://claude.ai/code/session_01SYHQXaS8AN4tQFh9EM9eLm