### PR TITLE
fix(nix): correct electron path — libexec/electron not lib/electron

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -299,13 +299,13 @@
         stable-nixos = mkClaudeDesktop {
           channel = "stable";
           inherit (stableMeta) version url sha256;
-          electronPath = "${pkgs.electron}/lib/electron";
+          electronPath = "${pkgs.electron}/libexec/electron";
         };
 
         dev-nixos = mkClaudeDesktop {
           channel = "dev";
           inherit (devMeta) version url sha256;
-          electronPath = "${pkgs.electron}/lib/electron";
+          electronPath = "${pkgs.electron}/libexec/electron";
         };
 
         # Computed at eval time — must be -1 for the check to pass.


### PR DESCRIPTION
nixpkgs' electron stores files at ${pkgs.electron}/libexec/electron/, not lib/electron/. The broken symlink caused noBrokenSymlinks check to fail the build.

https://claude.ai/code/session_01SYHQXaS8AN4tQFh9EM9eLm