### PR TITLE
fix(nix): rename deprecated xorg.* to new top-level package names

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -174,21 +174,19 @@
               # suspenders) via the extended LD_LIBRARY_PATH in the
               # launcher wrapper below.
               systemd
-              xorg.libX11
-              xorg.libXcomposite
-              xorg.libXdamage
-              xorg.libXext
-              xorg.libXfixes
-              xorg.libXrandr
-              xorg.libxcb
+              libx11
+              libxcomposite
+              libxdamage
+              libxext
+              libxfixes
+              libxrandr
+              libxcb
               # Additional X extensions that Electron dlopens on startup.
-              # Missing any of these causes autoPatchelfHook to fail the
-              # build with a clear "could not find dependency" message.
-              xorg.libXi
-              xorg.libXcursor
-              xorg.libXtst
-              xorg.libXrender
-              xorg.libXScrnSaver
+              libxi
+              libxcursor
+              libxtst
+              libxrender
+              libxscrnsaver
             ];
 
             runtimeDependencies = with pkgs; [


### PR DESCRIPTION
The xorg package set is deprecated in nixpkgs. Replace:
  xorg.libX11 → libx11
  xorg.libXcomposite → libxcomposite
  xorg.libXdamage → libxdamage
  xorg.libXext → libxext
  xorg.libXfixes → libxfixes
  xorg.libXrandr → libxrandr
  xorg.libxcb → libxcb
  xorg.libXi → libxi
  xorg.libXcursor → libxcursor
  xorg.libXtst → libxtst
  xorg.libXrender → libxrender
  xorg.libXScrnSaver → libxscrnsaver

https://claude.ai/code/session_01SYHQXaS8AN4tQFh9EM9eLm