### PR TITLE
fix(ci): pass correct input to build.yml in check-update workflow

### DIFF
--- a/.github/workflows/check-update.yml
+++ b/.github/workflows/check-update.yml
@@ -101,6 +101,5 @@ jobs:
           gh workflow run build.yml \
             --repo "${{ github.repository }}" \
             --ref main \
-            --field version="$UPSTREAM" \
-            --field release=true
-          echo "Triggered build.yml for version $UPSTREAM."
+            -f channel=stable
+          echo "Triggered build.yml (channel=stable) for version $UPSTREAM."


### PR DESCRIPTION
check-update.yml was passing --field version and --field release to build.yml, but build.yml only accepts a channel input. This caused "unexpected inputs" failures whenever a new upstream version was detected (runs #102-108 since April 14). Replace with -f channel=stable which matches build.yml's workflow_dispatch schema.

https://claude.ai/code/session_01GMAQF8tY1qxQ2NPzj8ibPm