### PR TITLE
fix(nix): sync stable channel metadata with main

### DIFF
--- a/nix/stable.json
+++ b/nix/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "version": "1.3109.0",
-  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.3109.0-repack-0/claude-desktop-1.3109.0-repack-0-x86_64-nix.tar.gz",
-  "sha256": "a1a9510b1eba471b3e2232bef9ace3ffed8e7241c995953ae597b4da72c4bf18"
+  "version": "1.8089.1",
+  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.8089.1-repack-0/claude-desktop-1.8089.1-repack-0-x86_64-nix.tar.gz",
+  "sha256": "e9f4b9c281c883725aa5fa455d15a7072b7a7cc63a7e0e92e8c885093affc031"
 }


### PR DESCRIPTION
## Summary
- Syncs `nix/stable.json` on dev branch from stale version `1.3109.0` to main's current `1.8089.1`
- Fixes `nix flake check` failure on dev: the dev channel version (`1.7196.1~dev...`) sorted **higher** than the outdated stable version, breaking the `channel-version-order` invariant
- This non-`[skip ci]` commit also triggers CI on PR #84 (dev → main), which had zero check runs because its HEAD was a bot `[skip ci]` commit

## Test plan
- [ ] `nix flake check` passes on dev branch (channel-version-order: dev < stable)
- [ ] CI (build.yml + smoke-test.yml) triggers and passes
- [ ] Stable channel URL/SHA256 matches the latest release on main

https://claude.ai/code/session_019tj5p9ELz22bCUqkK13NtX

---
_Generated by [Claude Code](https://claude.ai/code/session_019tj5p9ELz22bCUqkK13NtX)_