### PR TITLE
Update stable channel to version 1.11187.4

### DIFF
--- a/nix/stable.json
+++ b/nix/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "version": "1.5354.0",
-  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.5354.0-repack-0/claude-desktop-1.5354.0-repack-0-x86_64-nix.tar.gz",
-  "sha256": "220d3ad048987014d16bc3cb45fb5fe8b33af577a5cc384dc51563483cb43374"
+  "version": "1.6259.0",
+  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.6259.0-repack-0/claude-desktop-1.6259.0-repack-0-x86_64-nix.tar.gz",
+  "sha256": "53049e0d2565f9b77a0449acb0ec35bf2f461ad3f97f4dcafc32b542734e5681"
 }

--- a/nix/stable.json
+++ b/nix/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "version": "1.6259.0",
-  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.6259.0-repack-0/claude-desktop-1.6259.0-repack-0-x86_64-nix.tar.gz",
-  "sha256": "53049e0d2565f9b77a0449acb0ec35bf2f461ad3f97f4dcafc32b542734e5681"
+  "version": "1.6259.1",
+  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.6259.1-repack-0/claude-desktop-1.6259.1-repack-0-x86_64-nix.tar.gz",
+  "sha256": "07bcae3b7f624abce3e1fc5b7532a37bb9234ca7c43ded85b5e13bd05a133a9d"
 }

--- a/nix/stable.json
+++ b/nix/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "version": "1.3883.0",
-  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.3883.0-repack-0/claude-desktop-1.3883.0-repack-0-x86_64-nix.tar.gz",
-  "sha256": "864e3eea128ba8c0687ce56bf133626876ccfbb5a0bd5eef24504cf35c8369bb"
+  "version": "1.4758.0",
+  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.4758.0-repack-0/claude-desktop-1.4758.0-repack-0-x86_64-nix.tar.gz",
+  "sha256": "8c6a27ce02193a6c06ef7c3e75a650f3f12f99e7905b6797af07f4de56949e4f"
 }

--- a/nix/stable.json
+++ b/nix/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
   "version": "1.3109.0",
-  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.3109.0-repack-0/claude-desktop-1.3109.0-repack-0-x86_64-nix.tar.gz",
-  "sha256": "a1a9510b1eba471b3e2232bef9ace3ffed8e7241c995953ae597b4da72c4bf18"
+  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.3109.0-repack-1/claude-desktop-1.3109.0-repack-1-x86_64-nix.tar.gz",
+  "sha256": "cc9793c32921c93abb38f779dfd98a143ca175f2b35322fcbea582649473a759"
 }

--- a/nix/stable.json
+++ b/nix/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "version": "1.5220.0",
-  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.5220.0-repack-0/claude-desktop-1.5220.0-repack-0-x86_64-nix.tar.gz",
-  "sha256": "0b66db9d0a5d6b0e87bffa738f4f50401909e7a5ed7b6f2bfa96bd68a68bee25"
+  "version": "1.5354.0",
+  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.5354.0-repack-0/claude-desktop-1.5354.0-repack-0-x86_64-nix.tar.gz",
+  "sha256": "220d3ad048987014d16bc3cb45fb5fe8b33af577a5cc384dc51563483cb43374"
 }

--- a/nix/stable.json
+++ b/nix/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
   "version": "1.3109.0",
-  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.3109.0-repack-1/claude-desktop-1.3109.0-repack-1-x86_64-nix.tar.gz",
-  "sha256": "cc9793c32921c93abb38f779dfd98a143ca175f2b35322fcbea582649473a759"
+  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.3109.0-repack-2/claude-desktop-1.3109.0-repack-2-x86_64-nix.tar.gz",
+  "sha256": "a3f956fd12e97948337dcfe8fbc0ae620ab855a16e4e06b93ca35bfac702d47e"
 }

--- a/nix/stable.json
+++ b/nix/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "version": "1.4758.0",
-  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.4758.0-repack-0/claude-desktop-1.4758.0-repack-0-x86_64-nix.tar.gz",
-  "sha256": "8c6a27ce02193a6c06ef7c3e75a650f3f12f99e7905b6797af07f4de56949e4f"
+  "version": "1.5220.0",
+  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.5220.0-repack-0/claude-desktop-1.5220.0-repack-0-x86_64-nix.tar.gz",
+  "sha256": "0b66db9d0a5d6b0e87bffa738f4f50401909e7a5ed7b6f2bfa96bd68a68bee25"
 }

--- a/nix/stable.json
+++ b/nix/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "version": "1.3561.0",
-  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.3561.0-repack-0/claude-desktop-1.3561.0-repack-0-x86_64-nix.tar.gz",
-  "sha256": "b7793211bc002ea40dfeba77c7cb5f38abbc36ec9eac540ea1bd0f9381f36293"
+  "version": "1.3883.0",
+  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.3883.0-repack-0/claude-desktop-1.3883.0-repack-0-x86_64-nix.tar.gz",
+  "sha256": "864e3eea128ba8c0687ce56bf133626876ccfbb5a0bd5eef24504cf35c8369bb"
 }

--- a/nix/stable.json
+++ b/nix/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "version": "1.3109.0",
-  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.3109.0-repack-2/claude-desktop-1.3109.0-repack-2-x86_64-nix.tar.gz",
-  "sha256": "a3f956fd12e97948337dcfe8fbc0ae620ab855a16e4e06b93ca35bfac702d47e"
+  "version": "1.3561.0",
+  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.3561.0-repack-0/claude-desktop-1.3561.0-repack-0-x86_64-nix.tar.gz",
+  "sha256": "b7793211bc002ea40dfeba77c7cb5f38abbc36ec9eac540ea1bd0f9381f36293"
 }

--- a/nix/stable.json
+++ b/nix/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "version": "1.8089.0",
-  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.8089.0-repack-0/claude-desktop-1.8089.0-repack-0-x86_64-nix.tar.gz",
-  "sha256": "4e787dba0706fe9acab96e4ce4bcd845284d7b63ff7e6c4abbc6718d5629e3d5"
+  "version": "1.8089.1",
+  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.8089.1-repack-0/claude-desktop-1.8089.1-repack-0-x86_64-nix.tar.gz",
+  "sha256": "e9f4b9c281c883725aa5fa455d15a7072b7a7cc63a7e0e92e8c885093affc031"
 }

--- a/nix/stable.json
+++ b/nix/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "version": "1.7196.3",
-  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.7196.3-repack-0/claude-desktop-1.7196.3-repack-0-x86_64-nix.tar.gz",
-  "sha256": "69a70a66255414f1ae0af31e91579bde4668048b93ca7f8323ef6ae694ef042b"
+  "version": "1.8089.0",
+  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.8089.0-repack-0/claude-desktop-1.8089.0-repack-0-x86_64-nix.tar.gz",
+  "sha256": "4e787dba0706fe9acab96e4ce4bcd845284d7b63ff7e6c4abbc6718d5629e3d5"
 }

--- a/nix/stable.json
+++ b/nix/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "version": "1.9659.2",
-  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.9659.2-repack-0/claude-desktop-1.9659.2-repack-0-x86_64-nix.tar.gz",
-  "sha256": "2fd8fce6890b717a84fa51fb021f5b19d6d0934ff79d985e55efac3f64730863"
+  "version": "1.9659.4",
+  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.9659.4-repack-0/claude-desktop-1.9659.4-repack-0-x86_64-nix.tar.gz",
+  "sha256": "fa50a76238c639eb8590ac8a82be85894c59813dafe8b38840ba2303f55d32a2"
 }

--- a/nix/stable.json
+++ b/nix/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "version": "1.6608.2",
-  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.6608.2-repack-0/claude-desktop-1.6608.2-repack-0-x86_64-nix.tar.gz",
-  "sha256": "0505c7447d0df25784945a4d3cc60d15e912036a237c0334221cd3cc23fa295c"
+  "version": "1.7196.0",
+  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.7196.0-repack-0/claude-desktop-1.7196.0-repack-0-x86_64-nix.tar.gz",
+  "sha256": "662960ced2bda92a7e27d3fdaafe9e1dfa8bd12781a67e35d8e17db9bac2162f"
 }

--- a/nix/stable.json
+++ b/nix/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "version": "1.9659.1",
-  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.9659.1-repack-0/claude-desktop-1.9659.1-repack-0-x86_64-nix.tar.gz",
-  "sha256": "b31581ba1c78c408ee96908610bbef0710f1929601e8015d34c7838d8ee1f4f4"
+  "version": "1.9659.2",
+  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.9659.2-repack-0/claude-desktop-1.9659.2-repack-0-x86_64-nix.tar.gz",
+  "sha256": "2fd8fce6890b717a84fa51fb021f5b19d6d0934ff79d985e55efac3f64730863"
 }

--- a/nix/stable.json
+++ b/nix/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "version": "1.9255.2",
-  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.9255.2-repack-0/claude-desktop-1.9255.2-repack-0-x86_64-nix.tar.gz",
-  "sha256": "b27d2d0c403ab5e2e5da9221d0a73039c335fd9f2350da04c332a3e4d69b2c64"
+  "version": "1.9659.1",
+  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.9659.1-repack-0/claude-desktop-1.9659.1-repack-0-x86_64-nix.tar.gz",
+  "sha256": "b31581ba1c78c408ee96908610bbef0710f1929601e8015d34c7838d8ee1f4f4"
 }

--- a/nix/stable.json
+++ b/nix/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "version": "1.10628.2",
-  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.10628.2-repack-0/claude-desktop-1.10628.2-repack-0-x86_64-nix.tar.gz",
-  "sha256": "cd965d8f7c6213e9a683c6627a6e4f1863fd96d4ccf642d1564bb727da97313b"
+  "version": "1.11187.1",
+  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.11187.1-repack-0/claude-desktop-1.11187.1-repack-0-x86_64-nix.tar.gz",
+  "sha256": "d0c97bf81ad2de8b4c3b2d7f7f63547e845ead6abf5b26d1f33fa25a679e2671"
 }

--- a/nix/stable.json
+++ b/nix/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "version": "1.7196.0",
-  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.7196.0-repack-0/claude-desktop-1.7196.0-repack-0-x86_64-nix.tar.gz",
-  "sha256": "662960ced2bda92a7e27d3fdaafe9e1dfa8bd12781a67e35d8e17db9bac2162f"
+  "version": "1.7196.1",
+  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.7196.1-repack-0/claude-desktop-1.7196.1-repack-0-x86_64-nix.tar.gz",
+  "sha256": "f2f6316e265c8feedf2c28ce4885ac063230543aa79237710d75e39c0ae881d0"
 }

--- a/nix/stable.json
+++ b/nix/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "version": "1.11187.2",
-  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.11187.2-repack-0/claude-desktop-1.11187.2-repack-0-x86_64-nix.tar.gz",
-  "sha256": "61f12efbd3d93e0ebb346e0cd747a4754dca2510bed2af9a4d3962fd5c488041"
+  "version": "1.11187.3",
+  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.11187.3-repack-0/claude-desktop-1.11187.3-repack-0-x86_64-nix.tar.gz",
+  "sha256": "26831b5ec9e3f5f76e0792815ef80d9dfd3c8839fd70742ceffdfd67d73074c1"
 }

--- a/nix/stable.json
+++ b/nix/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "version": "1.6608.1",
-  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.6608.1-repack-0/claude-desktop-1.6608.1-repack-0-x86_64-nix.tar.gz",
-  "sha256": "3a3393fcd7b0a94a445939e3cdb2f49375b3b489cd689781f9938b78581ab378"
+  "version": "1.6608.2",
+  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.6608.2-repack-0/claude-desktop-1.6608.2-repack-0-x86_64-nix.tar.gz",
+  "sha256": "0505c7447d0df25784945a4d3cc60d15e912036a237c0334221cd3cc23fa295c"
 }

--- a/nix/stable.json
+++ b/nix/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "version": "1.9255.0",
-  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.9255.0-repack-0/claude-desktop-1.9255.0-repack-0-x86_64-nix.tar.gz",
-  "sha256": "e1e51937b674a679364c6bee435fa96b9c03199a04084579c199b7195a62f171"
+  "version": "1.9255.2",
+  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.9255.2-repack-0/claude-desktop-1.9255.2-repack-0-x86_64-nix.tar.gz",
+  "sha256": "b27d2d0c403ab5e2e5da9221d0a73039c335fd9f2350da04c332a3e4d69b2c64"
 }

--- a/nix/stable.json
+++ b/nix/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "version": "1.11187.3",
-  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.11187.3-repack-0/claude-desktop-1.11187.3-repack-0-x86_64-nix.tar.gz",
-  "sha256": "26831b5ec9e3f5f76e0792815ef80d9dfd3c8839fd70742ceffdfd67d73074c1"
+  "version": "1.11187.4",
+  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.11187.4-repack-0/claude-desktop-1.11187.4-repack-0-x86_64-nix.tar.gz",
+  "sha256": "304943705be64ae1aadb6f923dbd017b44f310a1ed1436ba842e96660a62d44f"
 }

--- a/nix/stable.json
+++ b/nix/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "version": "1.8089.1",
-  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.8089.1-repack-0/claude-desktop-1.8089.1-repack-0-x86_64-nix.tar.gz",
-  "sha256": "e9f4b9c281c883725aa5fa455d15a7072b7a7cc63a7e0e92e8c885093affc031"
+  "version": "1.8555.0",
+  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.8555.0-repack-0/claude-desktop-1.8555.0-repack-0-x86_64-nix.tar.gz",
+  "sha256": "ef6b33dcfa7419cffae33c421e6615e15c82437cf1db54d3ae19d33359cb04d6"
 }

--- a/nix/stable.json
+++ b/nix/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "version": "1.9659.4",
-  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.9659.4-repack-0/claude-desktop-1.9659.4-repack-0-x86_64-nix.tar.gz",
-  "sha256": "fa50a76238c639eb8590ac8a82be85894c59813dafe8b38840ba2303f55d32a2"
+  "version": "1.10628.0",
+  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.10628.0-repack-0/claude-desktop-1.10628.0-repack-0-x86_64-nix.tar.gz",
+  "sha256": "8a80e92b7bbfff7578ba89bd54d82ddf6ec0e73c4ef00c6c63b86fc7cfead144"
 }

--- a/nix/stable.json
+++ b/nix/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "version": "1.6608.0",
-  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.6608.0-repack-0/claude-desktop-1.6608.0-repack-0-x86_64-nix.tar.gz",
-  "sha256": "083bd9cccdc19b738ace34c89e24b7245f609718e58aa447a373d34e2af2b000"
+  "version": "1.6608.1",
+  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.6608.1-repack-0/claude-desktop-1.6608.1-repack-0-x86_64-nix.tar.gz",
+  "sha256": "3a3393fcd7b0a94a445939e3cdb2f49375b3b489cd689781f9938b78581ab378"
 }

--- a/nix/stable.json
+++ b/nix/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "version": "1.7196.1",
-  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.7196.1-repack-0/claude-desktop-1.7196.1-repack-0-x86_64-nix.tar.gz",
-  "sha256": "f2f6316e265c8feedf2c28ce4885ac063230543aa79237710d75e39c0ae881d0"
+  "version": "1.7196.3",
+  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.7196.3-repack-0/claude-desktop-1.7196.3-repack-0-x86_64-nix.tar.gz",
+  "sha256": "69a70a66255414f1ae0af31e91579bde4668048b93ca7f8323ef6ae694ef042b"
 }

--- a/nix/stable.json
+++ b/nix/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "version": "1.8555.1",
-  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.8555.1-repack-0/claude-desktop-1.8555.1-repack-0-x86_64-nix.tar.gz",
-  "sha256": "190b94154b225773863d5121f672e396e3d6c9748dd80088d91b986671eb6e49"
+  "version": "1.8555.2",
+  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.8555.2-repack-0/claude-desktop-1.8555.2-repack-0-x86_64-nix.tar.gz",
+  "sha256": "8db1b0bda5d32dcca56dd98e7c368c87547ef962a7e0bbde292518ee38a5d503"
 }

--- a/nix/stable.json
+++ b/nix/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "version": "1.8555.2",
-  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.8555.2-repack-0/claude-desktop-1.8555.2-repack-0-x86_64-nix.tar.gz",
-  "sha256": "8db1b0bda5d32dcca56dd98e7c368c87547ef962a7e0bbde292518ee38a5d503"
+  "version": "1.9255.0",
+  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.9255.0-repack-0/claude-desktop-1.9255.0-repack-0-x86_64-nix.tar.gz",
+  "sha256": "e1e51937b674a679364c6bee435fa96b9c03199a04084579c199b7195a62f171"
 }

--- a/nix/stable.json
+++ b/nix/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "version": "1.10628.0",
-  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.10628.0-repack-0/claude-desktop-1.10628.0-repack-0-x86_64-nix.tar.gz",
-  "sha256": "8a80e92b7bbfff7578ba89bd54d82ddf6ec0e73c4ef00c6c63b86fc7cfead144"
+  "version": "1.10628.2",
+  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.10628.2-repack-0/claude-desktop-1.10628.2-repack-0-x86_64-nix.tar.gz",
+  "sha256": "cd965d8f7c6213e9a683c6627a6e4f1863fd96d4ccf642d1564bb727da97313b"
 }

--- a/nix/stable.json
+++ b/nix/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "version": "1.6259.1",
-  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.6259.1-repack-0/claude-desktop-1.6259.1-repack-0-x86_64-nix.tar.gz",
-  "sha256": "07bcae3b7f624abce3e1fc5b7532a37bb9234ca7c43ded85b5e13bd05a133a9d"
+  "version": "1.6608.0",
+  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.6608.0-repack-0/claude-desktop-1.6608.0-repack-0-x86_64-nix.tar.gz",
+  "sha256": "083bd9cccdc19b738ace34c89e24b7245f609718e58aa447a373d34e2af2b000"
 }

--- a/nix/stable.json
+++ b/nix/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "version": "1.11187.1",
-  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.11187.1-repack-0/claude-desktop-1.11187.1-repack-0-x86_64-nix.tar.gz",
-  "sha256": "d0c97bf81ad2de8b4c3b2d7f7f63547e845ead6abf5b26d1f33fa25a679e2671"
+  "version": "1.11187.2",
+  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.11187.2-repack-0/claude-desktop-1.11187.2-repack-0-x86_64-nix.tar.gz",
+  "sha256": "61f12efbd3d93e0ebb346e0cd747a4754dca2510bed2af9a4d3962fd5c488041"
 }

--- a/nix/stable.json
+++ b/nix/stable.json
@@ -1,6 +1,6 @@
 {
   "channel": "stable",
-  "version": "1.8555.0",
-  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.8555.0-repack-0/claude-desktop-1.8555.0-repack-0-x86_64-nix.tar.gz",
-  "sha256": "ef6b33dcfa7419cffae33c421e6615e15c82437cf1db54d3ae19d33359cb04d6"
+  "version": "1.8555.1",
+  "url": "https://github.com/stslex/claude-desktop-linux/releases/download/v1.8555.1-repack-0/claude-desktop-1.8555.1-repack-0-x86_64-nix.tar.gz",
+  "sha256": "190b94154b225773863d5121f672e396e3d6c9748dd80088d91b986671eb6e49"
 }


### PR DESCRIPTION
## Summary
Updates the stable release channel configuration to point to the latest Claude Desktop Linux version.

## Changes
- Bumped version from 1.8089.1 to 1.11187.4
- Updated release download URL to the new version
- Updated SHA256 checksum for the new release artifact

## Details
This update changes the stable channel manifest to reference the newer repack release, ensuring users on the stable channel receive the latest available version when updating.

https://claude.ai/code/session_01MRQsNHY1qckPKfPR7y1wua