### PR TITLE
Make tray patches non-fatal and improve failure diagnostics

### DIFF
--- a/patches/fix-tray-icon.mjs
+++ b/patches/fix-tray-icon.mjs
@@ -219,9 +219,16 @@ if (winIds.length === 0) {
 }
 
 if (nonWinIds.length === 0) {
-  log('Could not find nativeTheme.shouldUseDarkColors identifier in non-Windows branch.');
+  // Upstream simplified the non-Windows path to a plain literal assignment
+  // (e.g. `e = "TrayIconTemplate.png"`), so there is no
+  // `<id>.nativeTheme.shouldUseDarkColors` chain that could reference an
+  // undefined identifier. The minifier bug this patch targets does not exist
+  // on this code path — nothing to fix, so this is a successful no-op rather
+  // than a failure.
+  log('Non-Windows branch has no nativeTheme.shouldUseDarkColors reference ' +
+      '(plain literal icon path) — no minifier bug to fix.');
   log(`  Non-Windows branch: ${src.slice(match.nonWinBranch.start, match.nonWinBranch.end)}`);
-  process.exit(1);
+  process.exit(0);
 }
 
 const correctId = winIds[0].name;

--- a/patches/fix-tray-rebuild-race.mjs
+++ b/patches/fix-tray-rebuild-race.mjs
@@ -197,6 +197,20 @@ if (!m.menuFuncName)       missing.push('menuFuncName');
 if (!m.iconPathVar)        missing.push('iconPathVar');
 if (!m.enabledLocalName)   missing.push('enabledLocalName');
 if (missing.length) {
+  // Dump the located function so the CI log captures the exact upstream
+  // shape. Patching minified third-party code is inherently brittle: when a
+  // new upstream version renames variables or restructures the rebuild fn,
+  // the extractor above stops resolving one of the five identifiers. Printing
+  // the body here lets the extractor be repaired without needing the bundle
+  // in hand (it is otherwise only reachable inside CI). patch-cowork.sh treats
+  // this exit non-fatally, so the dump surfaces as a build warning.
+  const SNIPPET_LIMIT = 2400;
+  const fnSrc = src0.slice(m.fnStart, Math.min(m.fnEnd, m.fnStart + SNIPPET_LIMIT));
+  const truncated = m.fnEnd - m.fnStart > SNIPPET_LIMIT ? ' (truncated)' : '';
+  log(`sig=${JSON.stringify(m.sig)} resolved={tray:${m.trayVarName},electron:${m.electronVarName},menu:${m.menuFuncName},iconPath:${m.iconPathVar},enabled:${m.enabledLocalName}}`);
+  log(`--- ${m.name}() source${truncated} ---`);
+  log(fnSrc);
+  log(`--- end ${m.name}() source ---`);
   die(`Located ${m.name}() but failed to extract identifiers: ${missing.join(', ')}`);
 }
 

--- a/scripts/patch-cowork.sh
+++ b/scripts/patch-cowork.sh
@@ -201,9 +201,18 @@ fi
 #                            + startup-window skip on nativeTheme.updated.
 # Fixes dead Quit/Show tray-menu items on Linux: the upstream rebuild fn
 # destroy()s + new Tray()s racing SNI/dbusmenu registration, so the DBus
-# host ends up bound to a stale Tray. Failure-mode is fail-loud: exit 1
-# (caught by the syntax-validation step below) rather than silently
-# producing a broken bundle.
+# host ends up bound to a stale Tray.
+#
+# Non-fatal: this is a quality-of-life fix for the Linux tray, not a launch
+# requirement, so a failure to match the (minified, frequently-rechurned)
+# upstream bundle must NOT block the whole release pipeline. The patch is
+# all-or-nothing and writes the bundle only after its own re-parse + marker
+# check passes — on any failure it leaves the bundle untouched, so skipping
+# it cannot produce a broken app.asar. The post-patch syntax validation,
+# validate-bundle.sh, and the smoke-test launch check remain as the gates
+# against a genuinely broken bundle. When this patch can't match, its log
+# (captured below) dumps the located function so the extractor can be
+# repaired against the new upstream shape.
 # ---------------------------------------------------------------------------
 log "Patching tray rebuild race (mutex + delay + fast-path + startup gate)..."
 
@@ -218,10 +227,11 @@ set -e
 cat "$TRAY_RACE_LOG" >&2
 
 if [[ $TRAY_RACE_EXIT -ne 0 ]]; then
-  log "ERROR: fix-tray-rebuild-race.mjs failed (exit $TRAY_RACE_EXIT) — tray menu items will be dead on Linux."
-  exit 1
+  log "WARNING: fix-tray-rebuild-race.mjs failed (exit $TRAY_RACE_EXIT) — tray menu items may be dead on Linux."
+  log "  Bundle left untouched (patch is all-or-nothing); build continues. See log above for the located function shape."
+else
+  log "Tray rebuild race patched."
 fi
-log "Tray rebuild race patched."
 
 # ---------------------------------------------------------------------------
 # Patch 2 — CCD platform: add linux-x64/linux-arm64 support

--- a/scripts/patch-cowork.sh
+++ b/scripts/patch-cowork.sh
@@ -227,9 +227,11 @@ set -e
 cat "$TRAY_RACE_LOG" >&2
 
 if [[ $TRAY_RACE_EXIT -ne 0 ]]; then
+  TRAY_RACE_STATUS="SKIPPED (could not match upstream bundle — see warning above)"
   log "WARNING: fix-tray-rebuild-race.mjs failed (exit $TRAY_RACE_EXIT) — tray menu items may be dead on Linux."
   log "  Bundle left untouched (patch is all-or-nothing); build continues. See log above for the located function shape."
 else
+  TRAY_RACE_STATUS="mutex + 250ms post-destroy delay + in-place fast-path + 3s startup gate"
   log "Tray rebuild race patched."
 fi
 
@@ -722,7 +724,7 @@ touch "$GUARD"
 log "------------------------------------------------------------"
 log "Patch summary"
 log "  Platform-gate patch : $GATE_SUMMARY (all gates patched to return {status:\"supported\"})"
-log "  Tray rebuild race   : mutex + 250ms post-destroy delay + in-place fast-path + 3s startup gate"
+log "  Tray rebuild race   : $TRAY_RACE_STATUS"
 log "  CCD platform patch  : linux-x64/linux-arm64 added to getHostPlatform + getBinaryPathIfReady"
 log "  VM download patch   : download_and_sdk_prepare returns early on Linux"
 log "  Bundle download gate: platform check bypassed for Linux"


### PR DESCRIPTION
## Summary
Changed the tray-related patches from hard failures that block the release pipeline to non-fatal warnings, while significantly improving diagnostic output when patches cannot be applied. This allows builds to continue even when upstream code changes prevent the patches from matching, since these are quality-of-life improvements rather than launch requirements.

## Key Changes

- **Converted tray rebuild race patch to non-fatal**: Changed from `exit 1` to a warning log when `fix-tray-rebuild-race.mjs` fails to match. The bundle is left untouched (patch is all-or-nothing), and the build continues since the tray menu is not a launch blocker.

- **Enhanced failure diagnostics in fix-tray-rebuild-race.mjs**: When identifier extraction fails, the script now dumps the located function source code (up to 2400 chars) to the CI log. This allows maintainers to repair the extractor without needing direct access to the bundle, addressing the brittleness of patching minified third-party code.

- **Fixed fix-tray-icon.mjs non-Windows path handling**: Changed from treating the non-Windows branch as a failure (`exit 1`) to a successful no-op (`exit 0`). Added detailed comments explaining that upstream simplified this code path to plain literal assignments, eliminating the minifier bug this patch targets on that branch.

- **Improved logging and documentation**: Updated comments in `patch-cowork.sh` to clarify that these patches are quality-of-life fixes, not launch requirements, and that the post-patch validation steps remain as the gates against genuinely broken bundles.

## Implementation Details

The changes maintain the "all-or-nothing" nature of the patches — they either fully apply or leave the bundle untouched — while making the build pipeline more resilient to upstream code changes. The diagnostic output (function signatures and source snippets) is captured in CI logs for troubleshooting without blocking the release.

https://claude.ai/code/session_014kh1bT9AYM5k2agxz587iG