### PR TITLE
fix: stop platform-gate over-match (wake-scheduler crash) + persist tokens via libsecret

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -312,7 +312,19 @@ if [ -n "\$WAYLAND_DISPLAY" ] && [ -z "\$ELECTRON_OZONE_PLATFORM_HINT" ]; then
   WAYLAND_FLAGS="--enable-features=UseOzonePlatform,WaylandWindowDecorations --ozone-platform=wayland"
 fi
 
-exec "${electronBin}" --class=claude-desktop \$WAYLAND_FLAGS --no-sandbox "$out/lib/claude-desktop/app" "\$@"
+# --password-store=gnome-libsecret: pin Electron's safeStorage backend to
+# libsecret (this closure already bundles it — see buildInputs above). When
+# launched from a Wayland compositor / minimal session, Electron's automatic
+# os_crypt backend detection often fails to identify the desktop environment
+# and reports safeStorage as unavailable, so OAuth tokens are never persisted
+# and the app re-runs the cookie→token exchange on every request (visible in
+# the log as repeated "safeStorage not available, tokens will not persist").
+# Pinning the backend makes safeStorage available and lets tokens persist.
+# If no secret-service is reachable at runtime Electron degrades gracefully
+# (isEncryptionAvailable() → false), i.e. no worse than the current state.
+SAFESTORAGE_FLAGS="--password-store=gnome-libsecret"
+
+exec "${electronBin}" --class=claude-desktop \$WAYLAND_FLAGS \$SAFESTORAGE_FLAGS --no-sandbox "$out/lib/claude-desktop/app" "\$@"
 LAUNCHER
                 chmod +x $out/bin/claude-desktop
               '' else ''

--- a/patches/find-platform-gate.mjs
+++ b/patches/find-platform-gate.mjs
@@ -295,6 +295,21 @@ for (const filePath of jsFiles) {
     const body = node.body;
     if (!body || body.type !== 'BlockStatement') return;
 
+    // MANDATORY: a platform/availability gate is *defined* by returning a
+    // `{ status: … }` object — that is the value apply-platform-gate.mjs
+    // overwrites the body with. Without this hard requirement the loose
+    // score >= THRESHOLD heuristic (especially in --all mode) also matches
+    // dozens of unrelated platform-branching helpers — path resolvers,
+    // config dispatchers, the wake-scheduler factory `Our`, etc. — that
+    // merely reference "darwin"/"win32"/"platform". Clobbering those to
+    // `return { status: "supported" }` silently breaks them (e.g. the
+    // wake-scheduler then throws "reconcile is not a function" because its
+    // factory now returns a status object instead of a scheduler). On
+    // 1.11187.4 this guard cuts the matched set from 49 → 15 while keeping
+    // every genuine gate. A real gate always returns a status object; if it
+    // does not, it is not a gate and must be left untouched.
+    if (!hasAnyStatusProperty(body)) return;
+
     const score = scoreBody(body, src);
     if (score === 0) return;
 


### PR DESCRIPTION
Two Linux-runtime fixes found while debugging Dispatch on the installed dev build (`1.11847.5`). Neither touches `INVARIANTS.md`, `patch-cowork.sh`, or the doc non-goal sections.

## 1. `find-platform-gate.mjs` — require a `{ status: … }` object to qualify as a gate

**Root cause of the `wake-scheduler` crash.** The scorer accepts any function ≥ 4/7, and in `--all` mode every match is rewritten to `return { status: "supported", config: {} }`. On a real bundle that hits **~49 functions**, not the 2–3 real availability gates — including path resolvers, config dispatchers, and the **wake-scheduler factory `Our()`**. Clobbering `Our()` makes it return a status object instead of a scheduler, so `Lur(Our(...))` throws on every launch:

```
[wake-scheduler] initial reconcile failed: TypeError: A.reconcile is not a function
```

A platform/availability gate is *defined* by returning a `{ status }` object (exactly what `apply-platform-gate.mjs` writes). Making that mandatory:

- **49 → 15** matched functions on 1.11187.4.
- Keeps **every** genuine gate: Cowork `WEr`/`XEr`, the `process.platform!=="darwin"?{status:"unavailable"}:…` checks, the `lt("1928275548")` feature-flag gate, `isClaudeCodeForDesktopEnabled`, etc.
- Single-best mode still returns the Cowork gate; exit codes unchanged.
- Only ever **removes** non-gate false positives → Cowork stays enabled (verified: real gates survive, `Our`/path/config helpers are dropped).

## 2. `flake.nix` — pin Electron safeStorage to `--password-store=gnome-libsecret`

The closure already bundles `libsecret`, but when launched from a Wayland session Electron's `os_crypt` backend auto-detection often fails to identify the desktop environment and reports safeStorage as **unavailable**. OAuth tokens then never persist and the cookie→token exchange re-runs constantly:

```
safeStorage not available, tokens will not persist
```

Pinning the backend makes safeStorage available so tokens persist. If no secret-service is reachable at runtime Electron degrades gracefully (`isEncryptionAvailable() → false`) — no worse than today. Scoped to the nix build only; the RPM/DEB/AppImage launchers are left to auto-detect so KDE/KWallet users aren't forced onto libsecret.

## Validation
- `node --check patches/find-platform-gate.mjs` ✓
- `nix eval .#packages.x86_64-linux.default.name` → `claude-desktop-1.11847.5` ✓
- Gate finder on the unpatched 1.11187.4 bundle: 15 gates emitted, all `{status}`-returning; Cowork gate still found in single mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)