### PR TITLE
feat(cowork): EXPERIMENTAL Linux computer-use backend (default off)

### DIFF
--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -45,9 +45,11 @@ entirely and run the Claude Code binary directly on the host.
 │   ├── claude-swift-pkg.json           ← package.json that ships inside the @ant/claude-swift stub
 │   ├── platform-headers.js             ← Anthropic API header injection (copied next to main entry by patch-cowork.sh)
 │   ├── ipc-stubs.js                    ← ComputerUseTcc IPC handler stubs (copied next to main entry)
-│   └── dispatch-polyfill.js            ← Dispatch IPC stubs + foreground polling (copied next to main entry)
+│   ├── dispatch-polyfill.js            ← Dispatch IPC stubs + foreground polling (copied next to main entry)
+│   └── computer-use-linux.js           ← EXPERIMENTAL Linux computer-use backend (grim screenshots + ydotool/wtype input); staged next to @ant/claude-swift only under ENABLE_EXPERIMENTAL_PATCHES=1, activated at runtime by ENABLE_COMPUTER_USE=1 (default off)
 ├── patches/
 │   ├── patch-utils.mjs                 ← shared helpers used by the three experimental AST patches
+│   ├── recon-computer-use.mjs          ← READ-ONLY acorn recon of the @ant/claude-swift computerUse contract (writes /tmp/cd-computeruse-recon.md); pairs with the COMPUTER_USE_RECON=1 runtime proxy in stubs/claude-swift.js
 │   ├── find-platform-gate.mjs          ← AST search for the Cowork availability gate
 │   ├── apply-platform-gate.mjs         ← replace platform-gate body with `return { status: "supported" }`
 │   ├── find-ccd-platform.mjs           ← locate CCD getHostPlatform / getBinaryPathIfReady
@@ -97,7 +99,9 @@ Invariants and non-goals are defined in INVARIANTS.md (change-protected, see .gi
 | `DISPATCH_DEBUG` | `` | Set to `1` for Dispatch IPC traffic logging |
 | `DISPATCH_POLL_INTERVAL_MS` | `30000` | Dispatch foreground polling interval (ms) |
 | `SKIP_DISPATCH_POLL` | `` | Set to `1` to disable Dispatch polling |
-| `ENABLE_EXPERIMENTAL_PATCHES` | `` | Set to `1` to run cowork-socket, dispatch, and computer-use-tcc AST patches (off by default — they corrupt the JS bundle) |
+| `ENABLE_EXPERIMENTAL_PATCHES` | `` | Set to `1` to run cowork-socket, dispatch, and computer-use-tcc AST patches (off by default — they corrupt the JS bundle), and to stage `stubs/computer-use-linux.js` next to the `@ant/claude-swift` stub |
+| `ENABLE_COMPUTER_USE` | `` | Runtime (read by `stubs/claude-swift.js`). With this AND `ENABLE_EXPERIMENTAL_PATCHES=1` (build), the `computerUse` namespace is backed by `stubs/computer-use-linux.js` (grim/ydotool). Default off → `computerUse` stays `null`. Single-output / no-fractional-scaling v1; full end-to-end also needs bundle changes that are a maintainer decision (INVARIANTS non-goal). |
+| `COMPUTER_USE_RECON` | `` | Runtime diagnostic. Replaces `computerUse` with a logging Proxy that appends live calls to `/tmp/cd-computeruse-recon.md` and returns permissive stand-ins. Never modifies the bundle; precedes `ENABLE_COMPUTER_USE`. |
 | `VERSION_SUFFIX` | `` | Appended to version in filenames and package metadata (e.g. `~dev.20260404.abc1234`); set automatically by CI |
 
 ## Build Dependencies
@@ -181,6 +185,19 @@ branch):
   control, hostLoopMode).
 - `patches/patch-computer-use-tcc.mjs` — AST-injects ComputerUseTcc IPC
   handler stubs into the main bundle.
+- Staging of `stubs/computer-use-linux.js` (the EXPERIMENTAL Linux
+  computer-use backend) next to the injected `@ant/claude-swift` stub.
+  This copy does **not** touch the bundle — it only makes the module
+  available for `stubs/claude-swift.js` to `require()` at runtime when
+  `ENABLE_COMPUTER_USE=1` is also set. With neither flag, `computerUse`
+  stays `null` and behaviour is unchanged. The backend uses `grim`
+  (screenshots) and `ydotool`/`wtype` (input); it is v1 (single output,
+  no fractional scaling). The interface it implements was reverse-engineered
+  read-only by `patches/recon-computer-use.mjs` + the `COMPUTER_USE_RECON=1`
+  proxy → `/tmp/cd-computeruse-recon.md`. NOTE: the stock bundle still
+  hard-gates Linux computer use (platform set, executor dispatch, capability
+  profiles); making it work end-to-end needs further bundle changes that
+  touch the `INVARIANTS.md` "No Computer Use" non-goal — a maintainer decision.
 
 Other env vars that affect `patch-cowork.sh` behaviour:
 

--- a/README.md
+++ b/README.md
@@ -620,7 +620,17 @@ below is set.
 
 | Flag | Default | What it gates |
 |---|---|---|
-| `ENABLE_EXPERIMENTAL_PATCHES` | unset (off) | When set to `1`, `scripts/patch-cowork.sh` additionally runs `patches/patch-cowork-socket.mjs` (named pipe → Unix socket transport), `patches/patch-dispatch.mjs` (GrowthBook feature flag overrides for Dispatch), and `patches/patch-computer-use-tcc.mjs` (ComputerUseTcc IPC stub AST injection). All three currently corrupt the JS bundle on some Claude Desktop versions and can cause SIGSEGV on launch — see `scripts/patch-cowork.sh` lines 342–414 and the `fix_cowork` branch. |
+| `ENABLE_EXPERIMENTAL_PATCHES` | unset (off) | When set to `1`, `scripts/patch-cowork.sh` additionally runs `patches/patch-cowork-socket.mjs` (named pipe → Unix socket transport), `patches/patch-dispatch.mjs` (GrowthBook feature flag overrides for Dispatch), and `patches/patch-computer-use-tcc.mjs` (ComputerUseTcc IPC stub AST injection), and stages `stubs/computer-use-linux.js` next to the `@ant/claude-swift` stub (see `ENABLE_COMPUTER_USE` below). The three AST patches currently corrupt the JS bundle on some Claude Desktop versions and can cause SIGSEGV on launch — see `scripts/patch-cowork.sh` lines 342–414 and the `fix_cowork` branch. |
+| `ENABLE_COMPUTER_USE` | unset (off) | **Runtime** flag (read by `stubs/claude-swift.js`, not the build). When set to `1` **and** the build ran with `ENABLE_EXPERIMENTAL_PATCHES=1` (which stages the backend module), the `@ant/claude-swift` `computerUse` namespace is backed by `stubs/computer-use-linux.js`: screenshots via **`grim`** (resized/JPEG-encoded via Electron `nativeImage`), input primitives via **`ydotool`** (absolute pointer + click + scroll, needs a running `ydotoold` with `/dev/uinput` access) with **`wtype`** as the keyboard fallback. With neither flag, `computerUse` stays `null` and the app is byte-for-byte unchanged. **Caveats:** this is v1 — it targets a **single output with no fractional scaling** (multi-output `-o` targeting and DIP↔px conversion are TODO); and the stock bundle still hard-gates Linux computer use in three places (`hBA` platform set, the executor-factory dispatch, capability profiles), so enabling it end-to-end additionally requires bundle changes that are a **maintainer decision** (they touch the `INVARIANTS.md` "No Computer Use" non-goal). The contract this backend implements is documented in `/tmp/cd-computeruse-recon.md`. |
+| `COMPUTER_USE_RECON` | unset (off) | **Runtime** diagnostic flag. When set to `1`, `stubs/claude-swift.js` replaces `computerUse` with a logging Proxy that appends every live call (`seq | method | argc | args`) to `/tmp/cd-computeruse-recon.md` and returns permissive stand-ins (a ≥1024-byte image so the orchestrator proceeds; `tcc.*` → true). Used to reverse-engineer the live call sequence; never modifies the bundle. Takes precedence over `ENABLE_COMPUTER_USE` when both are set. |
+
+Required packages for `ENABLE_COMPUTER_USE` (resolved at runtime; missing tools
+log once and degrade to a no-op rather than crashing): **`grim`** (screenshots,
+required), **`ydotool`** + a running **`ydotoold`** daemon with `/dev/uinput`
+access (pointer/keyboard input), and optionally **`wtype`** (keyboard fallback).
+Wayland compositor must support `wlr-screencopy` (for `grim`) and
+`wlr-virtual-pointer` / `virtual-keyboard` (for `ydotool`/`wtype`) — e.g. niri,
+Sway, Hyprland.
 
 `ENABLE_EXPERIMENTAL_PATCHES` is the canonical pattern for any new patch
 that is not yet safe to enable by default: gate the new step behind a

--- a/patches/recon-computer-use.mjs
+++ b/patches/recon-computer-use.mjs
@@ -1,0 +1,413 @@
+#!/usr/bin/env node
+/**
+ * recon-computer-use.mjs
+ *
+ * READ-ONLY diagnostic for the computer-use workstream.  It does NOT modify
+ * the bundle, repack the asar, or write anything except a single markdown
+ * report.
+ *
+ * Goal: establish *ground truth* about how the orchestrator consumes the
+ * `computerUse` namespace on the @ant/claude-swift default export, BEFORE any
+ * Linux backend is written.  Guessing the contract is forbidden — guessed
+ * shapes have caused SIGSEGV regressions in this repo before (see
+ * scripts/patch-cowork.sh, ENABLE_EXPERIMENTAL_PATCHES block).
+ *
+ * What it records, per call site:
+ *   - the full member-access chain rooted at `.computerUse`
+ *     (e.g. computerUse.apps.prepareDisplay), including accesses through
+ *     local aliases (`const dAA = A.computerUse; dAA.apps.…`);
+ *   - whether the access is a call, the source text of every argument;
+ *   - return-contract hints: await usage, destructured result keys;
+ *   - ±context so a human can read the minified surroundings.
+ *
+ * It also scans for the keyword strings "computerUse", "screenshot",
+ * "screencapture", "click", "mouseMove", "cursor", "type", "keyPress",
+ * "scroll" — full detail for the rare ones, per-file counts for the generic
+ * ones (click/type/scroll/cursor appear thousands of times in DOM code).
+ *
+ * Usage:
+ *   node patches/recon-computer-use.mjs [app-extracted-dir]
+ *
+ *   app-extracted-dir  default: $BUILD_DIR/app-extracted (BUILD_DIR default
+ *                      /tmp/claude-build).  Scans <dir>/.vite/build.
+ *
+ * Output:
+ *   - Markdown report written to /tmp/cd-computeruse-recon.md
+ *     (the COMPUTER_USE_RECON=1 runtime proxy in stubs/claude-swift.js
+ *     appends live call logs to the same file).
+ *   - Concise summary echoed to stderr.
+ *
+ * Exit codes:
+ *   0  Scan completed and report written (zero findings is a valid result).
+ *   1  Could not scan at all (app-extracted dir missing or no .js files).
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { join, relative } from 'path';
+import * as walk from 'acorn-walk';
+import { collectJsFiles, tryParse, createLogger } from './patch-utils.mjs';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+const SURROUND = 260;   // ~chars of source context around each finding
+const ARG_CAP  = 160;   // cap printed source per call argument
+const ALIAS_PASSES = 3; // alias-of-alias resolution depth
+
+// Rare keywords: report every string literal that CONTAINS one (case-insens).
+const RARE_KEYWORDS = ['computerUse', 'screencapture', 'screenshot', 'mouseMove', 'keyPress'];
+// Generic keywords: exact-match string literals, per-file counts only
+// (full detail would drown the report — "click"/"type" are DOM staples).
+const GENERIC_KEYWORDS = ['click', 'cursor', 'type', 'scroll'];
+
+const log = createLogger('recon-computer-use');
+
+// ---------------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------------
+const buildDir = process.env.BUILD_DIR || '/tmp/claude-build';
+const appDir = process.argv[2] || join(buildDir, 'app-extracted');
+const viteDir = join(appDir, '.vite', 'build');
+const reportPath = '/tmp/cd-computeruse-recon.md';
+
+if (!existsSync(viteDir)) {
+  log(`ERROR: ${viteDir} not found — run fetch-and-extract.sh first.`);
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Small AST helpers
+// ---------------------------------------------------------------------------
+
+/** Property name of a MemberExpression, or null when dynamically computed. */
+function propName(member) {
+  if (!member.computed && member.property.type === 'Identifier') {
+    return member.property.name;
+  }
+  if (member.computed && member.property.type === 'Literal' &&
+      typeof member.property.value === 'string') {
+    return member.property.value;
+  }
+  return null;
+}
+
+/** One-line, whitespace-collapsed source slice. */
+function slice(src, start, end, cap) {
+  let s = src.slice(Math.max(0, start), Math.min(src.length, end));
+  s = s.replace(/\s+/g, ' ');
+  if (cap && s.length > cap) s = s.slice(0, cap) + '…';
+  return s;
+}
+
+/** Markdown-safe cell text. */
+function cell(s) {
+  return String(s).replace(/\|/g, '\\|').replace(/`/g, "'");
+}
+
+/**
+ * Starting from a MemberExpression node (whose property is `.computerUse` or
+ * whose object is a known alias), climb the ancestor chain to collect the
+ * full access path, call info, and return-contract hints.
+ *
+ * @returns {{
+ *   chain: string[], isCall: boolean, args: object[]|null,
+ *   awaited: boolean, resultKeys: string[]|null, aliasTo: string|null,
+ *   destructuredKeys: string[]|null, top: object
+ * }}
+ */
+function climb(node, ancestors) {
+  const chain = [];
+  let current = node;
+  let i = ancestors.length - 2; // ancestors[last] === node
+
+  // Extend through `.a.b.c` as long as the parent member-accesses us.
+  while (i >= 0 && ancestors[i].type === 'MemberExpression' && ancestors[i].object === current) {
+    chain.push(propName(ancestors[i]) ?? '[computed]');
+    current = ancestors[i];
+    i--;
+  }
+
+  // Call?
+  let isCall = false;
+  let args = null;
+  if (i >= 0 && ancestors[i].type === 'CallExpression' && ancestors[i].callee === current) {
+    isCall = true;
+    args = ancestors[i].arguments;
+    current = ancestors[i];
+    i--;
+  }
+
+  // Skip ChainExpression wrappers (optional chaining).
+  while (i >= 0 && ancestors[i].type === 'ChainExpression') {
+    current = ancestors[i];
+    i--;
+  }
+
+  // Awaited?
+  let awaited = false;
+  if (i >= 0 && ancestors[i].type === 'AwaitExpression') {
+    awaited = true;
+    current = ancestors[i];
+    i--;
+  }
+
+  // Result destructuring / alias assignment.
+  let aliasTo = null;
+  let resultKeys = null;
+  let destructuredKeys = null;
+  if (i >= 0) {
+    const p = ancestors[i];
+    let target = null;
+    if (p.type === 'VariableDeclarator' && p.init === current) target = p.id;
+    if (p.type === 'AssignmentExpression' && p.right === current) target = p.left;
+    if (target) {
+      if (target.type === 'Identifier') {
+        if (isCall) {
+          // result alias, not a namespace alias — record nothing
+        } else {
+          aliasTo = target.name;
+        }
+      } else if (target.type === 'ObjectPattern') {
+        const keys = target.properties
+          .map((pr) => (pr.key && pr.key.name) || (pr.key && pr.key.value) || '[computed]');
+        if (isCall) resultKeys = keys;
+        else destructuredKeys = keys;
+      }
+    }
+  }
+
+  return { chain, isCall, args, awaited, resultKeys, aliasTo, destructuredKeys, top: current };
+}
+
+// ---------------------------------------------------------------------------
+// Scan
+// ---------------------------------------------------------------------------
+const files = collectJsFiles(viteDir, log);
+if (files.length === 0) {
+  log(`ERROR: no .js files under ${viteDir}`);
+  process.exit(1);
+}
+
+const accesses = [];        // computerUse-rooted member accesses / calls
+const aliasDecls = [];      // { file, name, root, offset }
+const rareLiterals = [];    // { file, value, offset, context }
+const genericCounts = {};   // file → keyword → count
+const rarePropHits = [];    // member accesses with rare keyword prop names
+
+for (const file of files) {
+  let src;
+  try { src = readFileSync(file, 'utf8'); } catch { continue; }
+  const relFile = relative(appDir, file);
+
+  const lower = src.toLowerCase();
+  const hasAny =
+    src.includes('computerUse') ||
+    RARE_KEYWORDS.some((k) => lower.includes(k.toLowerCase()));
+  // Generic keywords are counted only in files that matter for this recon;
+  // still record their counts everywhere so the report shows the noise floor.
+  const ast = tryParse(src, file, {}, log);
+  if (!ast) continue;
+
+  // ---- pass 1: direct `.computerUse` member accesses + literals ----------
+  const fileAliases = new Map(); // name → level (1 = computerUse itself)
+
+  walk.fullAncestor(ast, (node, _st, ancestors) => {
+    if (node.type === 'Literal' && typeof node.value === 'string') {
+      const v = node.value;
+      const vl = v.toLowerCase();
+      for (const k of RARE_KEYWORDS) {
+        if (vl.includes(k.toLowerCase())) {
+          rareLiterals.push({
+            file: relFile,
+            value: v.length > 80 ? v.slice(0, 80) + '…' : v,
+            offset: node.start,
+            context: slice(src, node.start - SURROUND / 2, node.end + SURROUND / 2, SURROUND),
+          });
+          break;
+        }
+      }
+      if (GENERIC_KEYWORDS.includes(v)) {
+        genericCounts[relFile] ??= {};
+        genericCounts[relFile][v] = (genericCounts[relFile][v] || 0) + 1;
+      }
+      return;
+    }
+
+    if (node.type !== 'MemberExpression') return;
+    const pn = propName(node);
+    if (pn === 'computerUse') {
+      const info = climb(node, ancestors);
+      const rootSrc = slice(src, node.object.start, node.object.end, 60);
+      accesses.push({
+        file: relFile, offset: node.start, root: `${rootSrc}.computerUse`,
+        via: 'direct', ...info,
+        argSrc: info.args ? info.args.map((a) => slice(src, a.start, a.end, ARG_CAP)) : null,
+        context: slice(src, node.start - SURROUND, node.start + SURROUND, SURROUND * 2),
+      });
+      if (info.aliasTo && info.chain.length === 0) {
+        fileAliases.set(info.aliasTo, 1);
+        aliasDecls.push({ file: relFile, name: info.aliasTo, root: rootSrc, offset: node.start });
+      }
+      return;
+    }
+    // Rare keyword used as a method/property name anywhere — these are
+    // uncommon enough to record globally (screenshot, mouseMove, keyPress…).
+    if (pn) {
+      const pl = pn.toLowerCase();
+      if (RARE_KEYWORDS.some((k) => k !== 'computerUse' && pl.includes(k.toLowerCase()))) {
+        const info = climb(node, ancestors);
+        rarePropHits.push({
+          file: relFile, offset: node.start,
+          access: `${slice(src, node.object.start, node.object.end, 60)}.${pn}`,
+          isCall: info.isCall,
+          argSrc: info.args ? info.args.map((a) => slice(src, a.start, a.end, ARG_CAP)) : null,
+          context: slice(src, node.start - SURROUND / 2, node.start + SURROUND / 2, SURROUND),
+        });
+      }
+    }
+  });
+
+  // ---- pass 2..N: accesses through aliases --------------------------------
+  // Name-based within the file: minified identifiers may collide across
+  // scopes, so every alias hit carries context for human verification.
+  for (let pass = 0; pass < ALIAS_PASSES && fileAliases.size > 0; pass++) {
+    const newAliases = new Map();
+    walk.fullAncestor(ast, (node, _st, ancestors) => {
+      if (node.type !== 'MemberExpression') return;
+      if (node.object.type !== 'Identifier') return;
+      const lvl = fileAliases.get(node.object.name);
+      if (!lvl) return;
+      // Only the *base* of a chain — inner links are covered by climb().
+      const parent = ancestors[ancestors.length - 2];
+      if (parent && parent.type === 'MemberExpression' && parent.object !== node) return;
+
+      const info = climb(node, ancestors);
+      const fullChain = [propName(node) ?? '[computed]', ...info.chain];
+      const already = accesses.some((a) => a.file === relFile && a.offset === node.start);
+      if (already) return;
+      accesses.push({
+        file: relFile, offset: node.start,
+        root: `${node.object.name}<alias L${lvl}>`,
+        via: `alias:${node.object.name}`,
+        ...info, chain: fullChain,
+        argSrc: info.args ? info.args.map((a) => slice(src, a.start, a.end, ARG_CAP)) : null,
+        context: slice(src, node.start - SURROUND, node.start + SURROUND, SURROUND * 2),
+      });
+      if (info.aliasTo && !fileAliases.has(info.aliasTo)) {
+        newAliases.set(info.aliasTo, lvl + 1);
+        aliasDecls.push({
+          file: relFile, name: info.aliasTo,
+          root: `${node.object.name}.${fullChain.join('.')}`, offset: node.start,
+        });
+      }
+    });
+    for (const [k, v] of newAliases) fileAliases.set(k, v);
+    if (newAliases.size === 0) break;
+  }
+
+  if (hasAny) log(`scanned ${relFile} (${src.length} bytes)`);
+}
+
+// ---------------------------------------------------------------------------
+// Aggregate: method → arg shapes → return hints → frequency
+// ---------------------------------------------------------------------------
+const methods = new Map(); // chainKey → { count, calls: [], reads: [] }
+for (const a of accesses) {
+  const key = a.chain.length ? a.chain.join('.') : '(bare computerUse access)';
+  const m = methods.get(key) || { count: 0, calls: [], reads: [] };
+  m.count++;
+  if (a.isCall) m.calls.push(a);
+  else m.reads.push(a);
+  methods.set(key, m);
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+const out = [];
+out.push('# computerUse interface recon');
+out.push('');
+out.push(`Generated by \`patches/recon-computer-use.mjs\` from \`${viteDir}\`.`);
+out.push(`Files scanned: ${files.length}.  Direct/alias namespace accesses: ${accesses.length}.`);
+out.push('');
+out.push('## 1. Method summary (static): method → args → return contract → frequency');
+out.push('');
+out.push('| method (chain on computerUse) | calls | args (source, per site) | return hints | freq |');
+out.push('|---|---|---|---|---|');
+for (const [key, m] of [...methods.entries()].sort((x, y) => y[1].count - x[1].count)) {
+  const argSets = m.calls.map((c) => `(${(c.argSrc || []).join(', ')})`);
+  const hints = m.calls.map((c) => {
+    const h = [];
+    if (c.awaited) h.push('awaited');
+    if (c.resultKeys) h.push(`result destructured → {${c.resultKeys.join(', ')}}`);
+    return h.join('; ');
+  }).filter(Boolean);
+  out.push(`| ${cell(key)} | ${m.calls.length} | ${cell(argSets.join(' ; ') || '—')} | ${cell([...new Set(hints)].join(' ; ') || '—')} | ${m.count} |`);
+}
+out.push('');
+out.push('## 2. Every namespace access (with context)');
+out.push('');
+for (const a of accesses.sort((x, y) => x.file.localeCompare(y.file) || x.offset - y.offset)) {
+  out.push(`### ${a.file} @ ${a.offset} — \`${a.root}${a.chain.length ? '.' + a.chain.join('.') : ''}\``);
+  out.push(`- via: ${a.via}; call: ${a.isCall}; awaited: ${a.awaited}`);
+  if (a.argSrc) out.push(`- args: \`(${a.argSrc.join(', ')})\``);
+  if (a.resultKeys) out.push(`- result destructured → \`{${a.resultKeys.join(', ')}}\``);
+  if (a.destructuredKeys) out.push(`- namespace destructured → \`{${a.destructuredKeys.join(', ')}}\``);
+  if (a.aliasTo) out.push(`- aliased to local \`${a.aliasTo}\``);
+  out.push('```');
+  out.push(a.context);
+  out.push('```');
+  out.push('');
+}
+out.push('## 3. Alias declarations');
+out.push('');
+out.push('| file | alias | bound to | offset |');
+out.push('|---|---|---|---|');
+for (const d of aliasDecls) {
+  out.push(`| ${cell(d.file)} | ${cell(d.name)} | ${cell(d.root)} | ${d.offset} |`);
+}
+out.push('');
+out.push(`## 4. Rare keyword string literals (${RARE_KEYWORDS.join(', ')})`);
+out.push('');
+for (const r of rareLiterals) {
+  out.push(`- **${cell(r.file)}** @ ${r.offset}: \`"${cell(r.value)}"\``);
+  out.push('  ```');
+  out.push('  ' + r.context);
+  out.push('  ```');
+}
+out.push('');
+out.push('## 5. Rare keyword property accesses (screenshot / screencapture / mouseMove / keyPress)');
+out.push('');
+for (const r of rarePropHits) {
+  out.push(`- **${cell(r.file)}** @ ${r.offset}: \`${cell(r.access)}\` call=${r.isCall}${r.argSrc ? ` args=(${cell(r.argSrc.join(', '))})` : ''}`);
+  out.push('  ```');
+  out.push('  ' + r.context);
+  out.push('  ```');
+}
+out.push('');
+out.push(`## 6. Generic keyword literal counts per file (exact match: ${GENERIC_KEYWORDS.join(', ')})`);
+out.push('');
+out.push('| file | ' + GENERIC_KEYWORDS.join(' | ') + ' |');
+out.push('|---|' + GENERIC_KEYWORDS.map(() => '---|').join(''));
+for (const [f, counts] of Object.entries(genericCounts)) {
+  out.push(`| ${cell(f)} | ` + GENERIC_KEYWORDS.map((k) => counts[k] || 0).join(' | ') + ' |');
+}
+out.push('');
+out.push('## 7. Runtime call log (appended by COMPUTER_USE_RECON=1 proxy)');
+out.push('');
+out.push('_Run the app with `COMPUTER_USE_RECON=1` and start a computer-use task;');
+out.push('the proxy in stubs/claude-swift.js appends `method | argCount | args` lines below._');
+out.push('');
+
+writeFileSync(reportPath, out.join('\n'), 'utf8');
+
+// ---------------------------------------------------------------------------
+// Summary to stderr
+// ---------------------------------------------------------------------------
+log(`Report written to ${reportPath}`);
+log(`Namespace accesses: ${accesses.length}; aliases: ${aliasDecls.length}; ` +
+    `rare literals: ${rareLiterals.length}; rare prop hits: ${rarePropHits.length}`);
+for (const [key, m] of methods) {
+  log(`  computerUse.${key} — ${m.calls.length} call(s), ${m.count} access(es)`);
+}
+process.exit(0);

--- a/scripts/patch-cowork.sh
+++ b/scripts/patch-cowork.sh
@@ -504,8 +504,33 @@ if [[ "${ENABLE_EXPERIMENTAL_PATCHES:-}" == "1" ]]; then
   else
     log "ComputerUseTcc IPC handlers patched."
   fi
+
+  # -------------------------------------------------------------------------
+  # Stage — EXPERIMENTAL Linux computer-use backend (DISABLED by default)
+  #
+  # Copy stubs/computer-use-linux.js next to the injected @ant/claude-swift
+  # stub so claude-swift.js can require('./computer-use-linux.js') AT RUNTIME
+  # when ENABLE_COMPUTER_USE=1 is ALSO set. The build-flag gate (this block,
+  # ENABLE_EXPERIMENTAL_PATCHES=1) controls the file's PRESENCE; the runtime
+  # flag controls activation — so BOTH are required. Without this step the
+  # runtime require fails gracefully and computerUse stays null.
+  # Contract recon: /tmp/cd-computeruse-recon.md.
+  # -------------------------------------------------------------------------
+  log "Staging experimental Linux computer-use backend..."
+  CU_SRC="$REPO_DIR/stubs/computer-use-linux.js"
+  CU_DEST_DIR="$APP_DIR/node_modules/@ant/claude-swift"
+  if [[ -f "$CU_SRC" && -d "$CU_DEST_DIR" ]]; then
+    if node --check "$CU_SRC" 2>/dev/null; then
+      cp "$CU_SRC" "$CU_DEST_DIR/computer-use-linux.js"
+      log "Staged computer-use-linux.js → @ant/claude-swift/ (set ENABLE_COMPUTER_USE=1 at runtime to activate)."
+    else
+      log "WARNING: $CU_SRC failed node --check; NOT staging (computerUse stays null)."
+    fi
+  else
+    log "WARNING: computer-use backend source or @ant/claude-swift dir missing; skipping (computerUse stays null)."
+  fi
 else
-  log "Skipping experimental patches (Cowork socket, Dispatch flags, ComputerUseTcc)."
+  log "Skipping experimental patches (Cowork socket, Dispatch flags, ComputerUseTcc, computer-use backend)."
   log "Set ENABLE_EXPERIMENTAL_PATCHES=1 to enable them."
 fi
 
@@ -789,6 +814,7 @@ log "  Dispatch gate       : checked (shared with Cowork gate or patched separat
 log "  Cowork socket       : $(if [[ "${ENABLE_EXPERIMENTAL_PATCHES:-}" == "1" ]]; then echo "named pipe → Unix domain socket on Linux"; else echo "SKIPPED (experimental)"; fi)"
 log "  Dispatch flags      : $(if [[ "${ENABLE_EXPERIMENTAL_PATCHES:-}" == "1" ]]; then echo "GrowthBook feature flags force-enabled for Linux"; else echo "SKIPPED (experimental)"; fi)"
 log "  ComputerUseTcc      : $(if [[ "${ENABLE_EXPERIMENTAL_PATCHES:-}" == "1" ]]; then echo "IPC stubs injected into main bundle"; else echo "SKIPPED (experimental)"; fi)"
+log "  Computer-use backend: $(if [[ "${ENABLE_EXPERIMENTAL_PATCHES:-}" == "1" ]]; then echo "staged next to @ant/claude-swift (run-time ENABLE_COMPUTER_USE=1 to activate)"; else echo "SKIPPED (experimental)"; fi)"
 log "  Patches injected    : $MAIN_ENTRY"
 log "    module-load-patch.js   (shared Module._load interceptor registry)"
 log "    shell-env-patch.js     (fix shell path worker not found on Linux)"

--- a/stubs/claude-swift.js
+++ b/stubs/claude-swift.js
@@ -485,6 +485,179 @@ const vm = new Proxy(_vmBase, {
 vm._callbacks = _callbacks;
 vm._procs     = _procs;
 
+// ===========================================================================
+// computerUse namespace resolution (EXPERIMENTAL — DISABLED BY DEFAULT)
+//
+// Three states, chosen by env flags:
+//   COMPUTER_USE_RECON=1  → install a logging Proxy that records the live call
+//                           sequence to /tmp/cd-computeruse-recon.md and returns
+//                           permissive stand-ins (Phase-1 runtime recon). This
+//                           NEVER touches the bundle; it just reveals the
+//                           contract. Active ONLY with the flag.
+//   ENABLE_COMPUTER_USE=1 → delegate to stubs/computer-use-linux.js (grim/ydotool
+//                           backend). The module is only present next to this
+//                           stub when the build ran with ENABLE_EXPERIMENTAL_PATCHES=1,
+//                           so BOTH conditions are required (recon §8.5).
+//   (neither)             → null, exactly as before. The orchestrator does
+//                           `if(!A.computerUse) throw` only ON USE, so a null
+//                           value is inert until a computer-use task starts.
+//
+// RECON takes precedence when both flags are set (it is the diagnostic path).
+// Every branch is wrapped so a failure degrades to null + a log line, never a
+// crash — `main` with default env is byte-for-byte unchanged in behaviour.
+// ===========================================================================
+const COMPUTER_USE_RECON_LOG = '/tmp/cd-computeruse-recon.md';
+
+/** Build a valid ≥1024-byte PNG (gradient) for recon screenshot stand-ins.
+ *  A 1×1 PNG would fail the orchestrator's decoded-length check (Lgt=1024)
+ *  and short-circuit the task — defeating the recon. See recon §8.6. */
+function _buildReconPngBase64(w, h) {
+  const zlib = require('zlib');
+  const crcTable = (() => {
+    const t = new Int32Array(256);
+    for (let n = 0; n < 256; n++) {
+      let c = n;
+      for (let k = 0; k < 8; k++) c = (c & 1) ? (0xEDB88320 ^ (c >>> 1)) : (c >>> 1);
+      t[n] = c;
+    }
+    return t;
+  })();
+  const crc32 = (buf) => {
+    let c = 0xFFFFFFFF;
+    for (let i = 0; i < buf.length; i++) c = crcTable[(c ^ buf[i]) & 0xFF] ^ (c >>> 8);
+    return (c ^ 0xFFFFFFFF) >>> 0;
+  };
+  const chunk = (type, data) => {
+    const len = Buffer.alloc(4); len.writeUInt32BE(data.length, 0);
+    const typeBuf = Buffer.from(type, 'ascii');
+    const body = Buffer.concat([typeBuf, data]);
+    const crc = Buffer.alloc(4); crc.writeUInt32BE(crc32(body), 0);
+    return Buffer.concat([len, body, crc]);
+  };
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(w, 0); ihdr.writeUInt32BE(h, 4);
+  ihdr[8] = 8; ihdr[9] = 6; ihdr[10] = 0; ihdr[11] = 0; ihdr[12] = 0; // 8-bit RGBA
+  const raw = Buffer.alloc((w * 4 + 1) * h);
+  let o = 0;
+  for (let y = 0; y < h; y++) {
+    raw[o++] = 0; // no filter
+    for (let x = 0; x < w; x++) {
+      raw[o++] = (x * 255 / w) | 0; raw[o++] = (y * 255 / h) | 0; raw[o++] = 128; raw[o++] = 255;
+    }
+  }
+  const png = Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]),
+    chunk('IHDR', ihdr),
+    chunk('IDAT', zlib.deflateSync(raw)),
+    chunk('IEND', Buffer.alloc(0)),
+  ]);
+  return png.toString('base64');
+}
+
+function _installReconProxy() {
+  const fs = require('fs');
+  const RECON_W = 1920, RECON_H = 1080;
+  let pngB64;
+  try { pngB64 = _buildReconPngBase64(160, 120); } // gradient → comfortably >1024 bytes
+  catch (_) { pngB64 = ''; }
+
+  let seq = 0;
+  const appendLog = (line) => {
+    try { fs.appendFileSync(COMPUTER_USE_RECON_LOG, line + '\n'); } catch (_) {}
+  };
+  const shortArgs = (args) => {
+    try {
+      return JSON.stringify(args.map((a) => {
+        if (Buffer.isBuffer(a)) return `<Buffer ${a.length}>`;
+        if (typeof a === 'string' && a.length > 60) return a.slice(0, 60) + '…';
+        if (typeof a === 'function') return '<fn>';
+        return a;
+      })).slice(0, 300);
+    } catch (_) { return '<unserialisable>'; }
+  };
+
+  // Permissive stand-ins keyed by full dotted path — chosen so the orchestrator
+  // PROCEEDS (recon §8.6) rather than erroring out.
+  const screenshotObj = () => ({
+    base64: pngB64, width: RECON_W, height: RECON_H,
+    displayWidth: RECON_W, displayHeight: RECON_H, displayId: 0, originX: 0, originY: 0,
+  });
+  const standIn = (path) => {
+    switch (path) {
+      case 'screenshot.captureExcluding': return screenshotObj();
+      case 'screenshot.captureRegion':    return { base64: pngB64 };
+      case 'resolvePrepareCapture':       return { ...screenshotObj(), hidden: [], activated: null };
+      case 'display.getSize':             return { width: RECON_W, height: RECON_H, scaleFactor: 1, originX: 0, originY: 0 };
+      case 'display.listAll':             return [{ displayId: 0, width: RECON_W, height: RECON_H, scaleFactor: 1, originX: 0, originY: 0, isPrimary: true, label: 'recon-0' }];
+      case 'tcc.checkAccessibility':
+      case 'tcc.checkScreenRecording':
+      case 'tcc.requestAccessibility':
+      case 'tcc.requestScreenRecording':  return true;
+      case 'apps.prepareDisplay':         return { activated: null, hidden: [] };
+      case 'apps.previewHideSet':
+      case 'apps.findWindowDisplays':
+      case 'apps.listInstalled':
+      case 'apps.listRunning':            return [];
+      case 'apps.appUnderPoint':
+      case 'apps.iconDataUrl':            return null;
+      default:                            return undefined; // open/unhide and unknowns
+    }
+  };
+
+  const logged = (path) => function (...args) {
+    appendLog(`${String(++seq).padStart(4, '0')} | computerUse.${path} | argc=${args.length} | ${shortArgs(args)}`);
+    return standIn(path);
+  };
+  const subNs = (prefix) => new Proxy({}, {
+    get(_t, p) {
+      if (typeof p === 'symbol') return undefined;
+      if (p === 'then') return undefined;
+      return logged(`${prefix}${String(p)}`);
+    },
+  });
+
+  appendLog(`\n## 7.live — COMPUTER_USE_RECON session (pid ${process.pid})`);
+  appendLog('seq | method | argc | args');
+  process.stderr.write('[claude-swift stub] COMPUTER_USE_RECON=1 — logging computerUse proxy installed → ' + COMPUTER_USE_RECON_LOG + '\n');
+
+  return new Proxy({}, {
+    get(_t, p) {
+      if (typeof p === 'symbol') return undefined;
+      if (p === 'then') return undefined; // never thenable
+      const key = String(p);
+      // Known sub-namespaces return a logging sub-proxy; everything else is a
+      // logged root-level method (e.g. resolvePrepareCapture).
+      if (key === 'apps' || key === 'display' || key === 'screenshot' || key === 'tcc') {
+        return subNs(`${key}.`);
+      }
+      return logged(key);
+    },
+  });
+}
+
+function resolveComputerUse() {
+  // Recon proxy first (diagnostic; self-contained; needs no backend module).
+  if (process.env.COMPUTER_USE_RECON === '1') {
+    try { return _installReconProxy(); }
+    catch (e) { process.stderr.write(`[claude-swift stub] recon proxy install failed: ${e.message}\n`); return null; }
+  }
+  // Real Linux backend — requires BOTH the runtime flag AND the module being
+  // present (copied next to this stub only under ENABLE_EXPERIMENTAL_PATCHES=1).
+  if (process.env.ENABLE_COMPUTER_USE === '1') {
+    try {
+      const backend = require('./computer-use-linux.js');
+      process.stderr.write('[claude-swift stub] ENABLE_COMPUTER_USE=1 — Linux computer-use backend active (EXPERIMENTAL)\n');
+      return backend.createComputerUse();
+    } catch (e) {
+      process.stderr.write(
+        `[claude-swift stub] ENABLE_COMPUTER_USE=1 but backend unavailable (${e.message}); ` +
+        'computerUse stays null. Did the build run with ENABLE_EXPERIMENTAL_PATCHES=1?\n');
+      return null;
+    }
+  }
+  return null; // default: identical to prior behaviour
+}
+
 // ---------------------------------------------------------------------------
 // Export shape — the app loads via dynamic import():
 //   Nr = (await import("@ant/claude-swift")).default
@@ -510,5 +683,7 @@ _module.quickAccess  = {
 };
 _module.midnightOwl  = { setEnabled() {} };
 _module.wakeScheduler = null;        // accessed as Nr?.wakeScheduler ?? null — null-guarded
-_module.computerUse  = null;         // guarded: if(!A.computerUse) throw — only throws on use
+// EXPERIMENTAL, default OFF: null unless COMPUTER_USE_RECON=1 or ENABLE_COMPUTER_USE=1.
+// The orchestrator does `if(!A.computerUse) throw` only ON USE, so null is inert.
+_module.computerUse  = resolveComputerUse();
 module.exports = _module;

--- a/stubs/computer-use-linux.js
+++ b/stubs/computer-use-linux.js
@@ -1,0 +1,606 @@
+'use strict';
+/**
+ * computer-use-linux.js  —  EXPERIMENTAL Linux backend for Cowork "computer use".
+ *
+ * DISABLED BY DEFAULT.  This module is only loaded when BOTH of these hold:
+ *   - build-time : ENABLE_EXPERIMENTAL_PATCHES=1 (scripts/patch-cowork.sh copies
+ *                  this file next to the injected @ant/claude-swift stub);
+ *   - run-time   : ENABLE_COMPUTER_USE=1 (checked in stubs/claude-swift.js,
+ *                  which require()s this module and sets `computerUse`).
+ * With neither flag, claude-swift.js leaves `computerUse = null` and the app
+ * behaves exactly as before.
+ *
+ * ───────────────────────────────────────────────────────────────────────────
+ * WHAT THIS IMPLEMENTS — and the boundary that recon established
+ * ───────────────────────────────────────────────────────────────────────────
+ * The full contract is in /tmp/cd-computeruse-recon.md (Section 8).  Two
+ * separate native surfaces back "computer use" on macOS/Windows:
+ *
+ *   1. @ant/claude-swift  .computerUse  ← THIS module's `createComputerUse()`
+ *        display.getSize / display.listAll
+ *        screenshot.captureExcluding / screenshot.captureRegion
+ *        resolvePrepareCapture            (root-level fn)
+ *        tcc.checkAccessibility / tcc.checkScreenRecording / request*
+ *        apps.{prepareDisplay,previewHideSet,findWindowDisplays,appUnderPoint,
+ *              listInstalled,iconDataUrl,listRunning,open,unhide}
+ *      → screenshots via `grim`; resize+JPEG via Electron nativeImage.
+ *
+ *   2. @ant/claude-native  (mouse/keyboard)  ← THIS module's `createInput()`
+ *        moveMouse / mouseButton / mouseScroll / keys / key / typeText /
+ *        mouseLocation / getFrontmostAppInfo
+ *      → `ydotool` (absolute pointer + click + type + key + scroll),
+ *        keyboard fallback `wtype`.
+ *
+ * Putting input methods on the `computerUse` namespace would CONTRADICT the
+ * recon (they are not members of it) — guessing the contract has caused a
+ * SIGSEGV regression here before — so `createInput()` is exported separately
+ * for a future, deliberate wiring into stubs/claude-native.js.  It is NOT wired
+ * by this change.
+ *
+ * IMPORTANT — this module alone does NOT enable end-to-end computer use on
+ * Linux.  The stock bundle hard-gates Linux in three places (recon §8.5):
+ *   (a) hBA = Set(["darwin","win32"])  → ib() false → tool reports "disabled";
+ *   (b) executor dispatch is `win32?createWin32Executor:createDarwinExecutor`
+ *       with NO linux branch → it THROWS at construction on Linux;
+ *   (c) no linux capability profile.
+ * Lifting those requires AST patches in the minified bundle and contradicts the
+ * INVARIANTS.md "No Computer Use" non-goal → a maintainer decision, out of scope.
+ *
+ * ───────────────────────────────────────────────────────────────────────────
+ * COORDINATE SPACE — the single correctness risk (recon §8.4)
+ * ───────────────────────────────────────────────────────────────────────────
+ * The orchestrator's converter Yx maps model coords (in the downsampled
+ * screenshot-image pixel space) to click coords with:
+ *     clickX = round(modelX * lastShot.displayWidth / lastShot.width) + originX
+ * and passes the result UNTRANSFORMED to the input backend.  So the ONE
+ * invariant a Linux backend must hold is:
+ *     screenshot.{displayWidth,displayHeight,originX,originY}  (and
+ *     display.getSize().{width,height,scaleFactor,originX,originY})  MUST be
+ *     in the SAME coordinate space that ydotool's absolute pointer consumes.
+ * All of that mapping is centralised in ONE function: coordSpace() below.
+ *
+ * v1 ASSUMPTION (documented + asserted): a SINGLE output, scaleFactor = 1, no
+ * fractional scaling, origin (0,0).  Then native px == logical px == ydotool
+ * absolute px and the transform is the identity.  Multi-output (originX/originY
+ * offsets, per-output grim `-o`) and fractional scaling (DIP↔px) are TODO.
+ */
+
+const { spawn, execFileSync } = require('child_process');
+
+const TAG = '[computer-use-linux]';
+const DEBUG = process.env.COWORK_DEBUG === '1' || process.env.COMPUTER_USE_DEBUG === '1';
+
+function log(msg)  { process.stderr.write(`${TAG} ${msg}\n`); }
+function debug(msg) { if (DEBUG) process.stderr.write(`${TAG} ${msg}\n`); }
+
+// ---------------------------------------------------------------------------
+// Electron handles (this module runs in the Electron main process).  Resolved
+// lazily and defensively so the file is require()-able under plain Node too
+// (the build-time `node --check` / self-test path).
+// ---------------------------------------------------------------------------
+function electron() {
+  try { return require('electron'); } catch { return null; }
+}
+
+// ---------------------------------------------------------------------------
+// Tool detection — runs ONCE at module load.  Missing tools degrade to a
+// logged no-op; they never throw or crash the app.
+// ---------------------------------------------------------------------------
+function detectTool(bin) {
+  try {
+    execFileSync('which', [bin], { stdio: ['ignore', 'ignore', 'ignore'], timeout: 2000 });
+    return true;
+  } catch { return false; }
+}
+
+const TOOLS = {
+  grim:    detectTool('grim'),
+  ydotool: detectTool('ydotool'),
+  wtype:   detectTool('wtype'),
+};
+
+(function reportToolsOnce() {
+  const present = Object.entries(TOOLS).filter(([, v]) => v).map(([k]) => k);
+  const missing = Object.entries(TOOLS).filter(([, v]) => !v).map(([k]) => k);
+  log(`tools present: [${present.join(', ') || 'none'}]  missing: [${missing.join(', ') || 'none'}]`);
+  if (!TOOLS.grim) {
+    log('WARNING: `grim` not found — screenshots will be no-ops. Install: grim');
+  }
+  if (!TOOLS.ydotool && !TOOLS.wtype) {
+    log('WARNING: neither `ydotool` nor `wtype` found — input will be no-ops. Install: ydotool (+ydotoold) and/or wtype');
+  }
+})();
+
+// ---------------------------------------------------------------------------
+// Process helper — spawn a tool, collect stdout as a Buffer, time-limited.
+// Rejects on non-zero exit / spawn error / timeout.  Never throws synchronously.
+// ---------------------------------------------------------------------------
+function run(bin, args, { timeout = 8000, input } = {}) {
+  return new Promise((resolve, reject) => {
+    let child;
+    try {
+      child = spawn(bin, args, { env: process.env, stdio: ['pipe', 'pipe', 'pipe'] });
+    } catch (e) {
+      reject(new Error(`spawn ${bin} failed: ${e.message}`));
+      return;
+    }
+    const out = [];
+    const err = [];
+    let settled = false;
+    const done = (fn, arg) => { if (!settled) { settled = true; clearTimeout(timer); fn(arg); } };
+    const timer = setTimeout(() => {
+      try { child.kill('SIGKILL'); } catch {}
+      done(reject, new Error(`${bin} timed out after ${timeout}ms`));
+    }, timeout);
+
+    child.stdout.on('data', (d) => out.push(d));
+    child.stderr.on('data', (d) => err.push(d));
+    child.on('error', (e) => done(reject, new Error(`${bin}: ${e.message}`)));
+    child.on('close', (code) => {
+      if (code === 0) done(resolve, Buffer.concat(out));
+      else done(reject, new Error(`${bin} exited ${code}: ${Buffer.concat(err).toString().trim().slice(0, 200)}`));
+    });
+
+    if (input != null) {
+      child.stdin.on('error', () => {}); // ignore EPIPE
+      child.stdin.end(input);
+    } else {
+      child.stdin.end();
+    }
+  });
+}
+
+// ===========================================================================
+// COORDINATE SPACE — the single centralized transform (recon §8.4).
+// ===========================================================================
+/**
+ * Given a canonical display descriptor, return the mapping between the
+ * captured screenshot's native pixels and the global click space that the
+ * input backend (ydotool absolute) consumes.
+ *
+ * v1: single output, scaleFactor forced to 1, origin (0,0) — identity.
+ * Multi-output / fractional scaling = TODO (see file header).
+ *
+ * @param {{width:number,height:number,scaleFactor:number,originX:number,originY:number}} display
+ * @returns {{pxWidth:number,pxHeight:number,originX:number,originY:number,scaleFactor:number}}
+ */
+let _warnedScale = false;
+
+/**
+ * THE v1 scale assumption, in ONE place. v1 supports only scaleFactor == 1.
+ * If the compositor reports fractional/HiDPI scaling we force 1 anyway (so the
+ * whole pipeline — getSize, listAll, capture — stays internally consistent) and
+ * warn LOUDLY once, because clicks WILL be miscalibrated until multi-scale
+ * support lands. Never silently produce wrong coordinates.
+ */
+function assumedScaleFactor(display) {
+  if (display && display.scaleFactor && display.scaleFactor !== 1 && !_warnedScale) {
+    _warnedScale = true;
+    log(`WARNING: display reports scaleFactor=${display.scaleFactor}; v1 supports ONLY 1 ` +
+        '(single output, no fractional scaling). Forcing 1 — clicks will be MISCALIBRATED ' +
+        'on this display until multi-scale support is added (TODO).');
+  }
+  return 1;
+}
+
+function coordSpace(display) {
+  // v1 hard assumption: no fractional scaling — routed through assumedScaleFactor().
+  const scaleFactor = assumedScaleFactor(display);
+  return {
+    pxWidth:  Math.max(1, Math.round(display.width  * scaleFactor)),
+    pxHeight: Math.max(1, Math.round(display.height * scaleFactor)),
+    // v1 single output => origin is (0,0); preserved here so multi-output is a
+    // one-function change.
+    originX: display.originX | 0,
+    originY: display.originY | 0,
+    scaleFactor,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Display enumeration.  Prefer Electron's screen API (authoritative — it is
+// the same source the win32 path uses for display rects).  Fall back to a
+// single synthetic display derived from a grim capture if Electron is absent.
+// ---------------------------------------------------------------------------
+function sanitizeLabel(s) {
+  if (typeof s !== 'string') return '';
+  return s.replace(/[^A-Za-z0-9 _.\-]/g, '').trim().slice(0, 40);
+}
+
+let _fallbackDims = null; // cached {width,height} from a probe capture
+
+function describeDisplays() {
+  const e = electron();
+  if (e && e.screen) {
+    try {
+      const all = e.screen.getAllDisplays();
+      const primaryId = e.screen.getPrimaryDisplay().id;
+      if (all && all.length) {
+        return all.map((d) => ({
+          displayId: d.id,
+          width: d.size.width,
+          height: d.size.height,
+          scaleFactor: d.scaleFactor || 1,
+          originX: (d.bounds && d.bounds.x) | 0,
+          originY: (d.bounds && d.bounds.y) | 0,
+          isPrimary: d.id === primaryId,
+          label: sanitizeLabel(d.label) || `display ${d.id}`,
+        }));
+      }
+    } catch (err) {
+      debug(`electron screen enumeration failed: ${err.message}`);
+    }
+  }
+  // Fallback: a single display, size from a cached grim probe (or a default).
+  const w = (_fallbackDims && _fallbackDims.width) || 1920;
+  const h = (_fallbackDims && _fallbackDims.height) || 1080;
+  return [{
+    displayId: 0, width: w, height: h, scaleFactor: 1,
+    originX: 0, originY: 0, isPrimary: true, label: 'display 0',
+  }];
+}
+
+function resolveDisplay(displayId) {
+  const all = describeDisplays();
+  return all.find((d) => d.displayId === displayId)
+      || all.find((d) => d.isPrimary)
+      || all[0];
+}
+
+// ---------------------------------------------------------------------------
+// Screenshot capture: grim → (Electron nativeImage resize + JPEG) → base64.
+// Mirrors the win32 path (nativeImage.resize().toJPEG()) so the return shape
+// and the image/jpeg mimeType the orchestrator hardcodes both hold.
+// `geometry` (optional) = { x, y, w, h } in display logical points → grim -g.
+// ---------------------------------------------------------------------------
+async function grimCapture(display, geometry) {
+  if (!TOOLS.grim) throw new Error('grim not installed');
+  const args = [];
+  // v1: single output → no `-o`. Multi-output TODO: args.push('-o', outputName).
+  if (geometry) {
+    args.push('-g', `${Math.round(geometry.x)},${Math.round(geometry.y)} ${Math.round(geometry.w)}x${Math.round(geometry.h)}`);
+  }
+  args.push('-t', 'png', '-'); // PNG to stdout (lossless source; re-encoded below)
+  const png = await run('grim', args, { timeout: 8000 });
+  if (!png || png.length === 0) throw new Error('grim produced no output');
+  return png;
+}
+
+/**
+ * Capture + encode to the orchestrator's contract.
+ * @returns {{base64,width,height,displayWidth,displayHeight,displayId,originX,originY}}
+ */
+async function captureToContract(display, targetMaxW, targetMaxH, quality, geometry) {
+  const space = coordSpace(display);
+  const png = await grimCapture(display, geometry);
+  const q = Math.max(1, Math.min(100, Math.round((quality == null ? 0.75 : quality) * 100)));
+
+  const e = electron();
+  let base64, outW, outH;
+  if (e && e.nativeImage) {
+    let img = e.nativeImage.createFromBuffer(png);
+    if (img.isEmpty()) throw new Error('nativeImage decode failed (empty)');
+    if (targetMaxW && targetMaxH) {
+      img = img.resize({ width: Math.round(targetMaxW), height: Math.round(targetMaxH), quality: 'good' });
+    }
+    const sz = img.getSize();
+    outW = sz.width; outH = sz.height;
+    base64 = img.toJPEG(q).toString('base64');
+  } else {
+    // No Electron (self-test / headless): grim the JPEG directly, no resize.
+    const jpeg = await run('grim', [
+      ...(geometry ? ['-g', `${Math.round(geometry.x)},${Math.round(geometry.y)} ${Math.round(geometry.w)}x${Math.round(geometry.h)}`] : []),
+      '-t', 'jpeg', '-q', String(q), '-',
+    ], { timeout: 8000 });
+    base64 = jpeg.toString('base64');
+    outW = geometry ? Math.round(geometry.w) : space.pxWidth;
+    outH = geometry ? Math.round(geometry.h) : space.pxHeight;
+    if (!_fallbackDims && !geometry) _fallbackDims = { width: outW, height: outH };
+  }
+
+  return {
+    base64,
+    width: outW,
+    height: outH,
+    displayWidth: space.pxWidth,
+    displayHeight: space.pxHeight,
+    displayId: display.displayId,
+    originX: space.originX,
+    originY: space.originY,
+  };
+}
+
+// ===========================================================================
+// computerUse NAMESPACE  (the @ant/claude-swift surface)
+// ===========================================================================
+function buildComputerUse() {
+  const impl = {
+    // -- display ------------------------------------------------------------
+    display: {
+      getSize(displayId) {
+        const d = resolveDisplay(displayId);
+        if (!d) throw new Error('No displays enumerated');
+        // scaleFactor routed through the v1 assumption so the executor's
+        // width*scaleFactor capture-target math matches the px we report.
+        return {
+          width: d.width, height: d.height, scaleFactor: assumedScaleFactor(d),
+          originX: d.originX, originY: d.originY,
+        };
+      },
+      listAll() {
+        return describeDisplays().map((d) => ({
+          displayId: d.displayId, width: d.width, height: d.height,
+          scaleFactor: assumedScaleFactor(d), originX: d.originX, originY: d.originY,
+          isPrimary: d.isPrimary, label: d.label,
+        }));
+      },
+    },
+
+    // -- screenshot ---------------------------------------------------------
+    screenshot: {
+      // captureExcluding(allowedBundleIds, quality, targetMaxW, targetMaxH, displayId)
+      // Wayland has no per-window exclusion via grim; allowedBundleIds is
+      // accepted and ignored (v1). Whole-display capture.
+      async captureExcluding(_allowedBundleIds, quality, targetMaxW, targetMaxH, displayId) {
+        const d = resolveDisplay(displayId);
+        return captureToContract(d, targetMaxW, targetMaxH, quality, null);
+      },
+      // captureRegion(allowedBundleIds, x, y, w, h, targetMaxW, targetMaxH, quality, displayId)
+      // x/y/w/h in display logical points. Only .base64 is consumed downstream,
+      // but we return the full contract shape for safety.
+      async captureRegion(_allowedBundleIds, x, y, w, h, targetMaxW, targetMaxH, quality, displayId) {
+        const d = resolveDisplay(displayId);
+        return captureToContract(d, targetMaxW, targetMaxH, quality, { x, y, w, h });
+      },
+    },
+
+    // -- resolvePrepareCapture (root-level fn) ------------------------------
+    // (allowedBundleIds, hostBundleId, quality, targetMaxW, targetMaxH,
+    //  preferredDisplayId, autoResolve, doHide) → capture + {hidden, activated}.
+    // We do not hide apps on Wayland (no equivalent), so hidden=[] activated=null.
+    async resolvePrepareCapture(allowedBundleIds, _hostBundleId, quality, targetMaxW, targetMaxH, preferredDisplayId, _autoResolve, _doHide) {
+      const d = resolveDisplay(preferredDisplayId);
+      try {
+        const shot = await captureToContract(d, targetMaxW, targetMaxH, quality, null);
+        return { ...shot, hidden: [], activated: null };
+      } catch (err) {
+        // Mirror the win32 graceful-failure shape so the tool surfaces a clean
+        // capture_failed rather than throwing.
+        return {
+          base64: '', width: 0, height: 0, displayWidth: 0, displayHeight: 0,
+          displayId: (preferredDisplayId != null ? preferredDisplayId : (d ? d.displayId : 0)),
+          originX: 0, originY: 0, hidden: [], activated: null,
+          captureError: err instanceof Error ? err.message : 'Screenshot capture failed',
+        };
+      }
+    },
+
+    // -- tcc (Linux has no TCC; permission is implicit) ---------------------
+    // ensureOsPermissions (DPA) needs BOTH check* truthy to grant on non-win32.
+    tcc: {
+      checkAccessibility() { return true; },
+      checkScreenRecording() { return true; },
+      requestAccessibility() { return true; },
+      requestScreenRecording() { return true; },
+    },
+
+    // -- apps (no Wayland equivalent for global app/window enumeration) -----
+    // All return the consumer's safe-default shapes (recon §8.2) so the grant
+    // dialog / hide flow degrade gracefully instead of breaking the loop.
+    apps: {
+      prepareDisplay(_allowedBundleIds, _hostBundleId, _displayId) { return { activated: null, hidden: [] }; },
+      previewHideSet(_bundleIds, _displayId) { return []; },
+      findWindowDisplays(_bundleIds) { return []; },
+      appUnderPoint(_x, _y) { return null; },
+      listInstalled() { return []; },
+      iconDataUrl(_path) { return null; },
+      listRunning() { return []; },
+      async open(_bundleId) { /* no-op (no bundle-id launch model on Linux) */ },
+      async unhide(_bundleIds) { /* no-op (nothing is hidden) */ },
+    },
+  };
+
+  // Wrap in a logging Proxy so any namespace member NOT positively identified
+  // in Phase 1 degrades to a logged no-op (returning undefined) rather than
+  // throwing — keeping `main` green. Mirrors the `vm` Proxy in claude-swift.js.
+  const warned = new Set();
+  const noop = (path) => function (...a) {
+    if (!warned.has(path)) { warned.add(path); log(`UNIMPLEMENTED computerUse.${path} (${a.length} args) — logging no-op`); }
+    return undefined;
+  };
+  const wrapNs = (obj, prefix) => new Proxy(obj, {
+    get(t, p) {
+      if (p in t) return t[p];
+      if (typeof p === 'symbol') return t[p];
+      return noop(`${prefix}${String(p)}`);
+    },
+  });
+
+  return new Proxy(impl, {
+    get(t, p) {
+      if (typeof p === 'symbol') return t[p];
+      if (p === 'then') return undefined; // never thenable
+      const v = t[p];
+      if (v && typeof v === 'object' && !Array.isArray(v)) return wrapNs(v, `${String(p)}.`);
+      if (p in t) return v;
+      return noop(String(p));
+    },
+  });
+}
+
+// ===========================================================================
+// INPUT primitives  (the @ant/claude-native surface — exported, NOT wired)
+// ===========================================================================
+// macOS-style key name → wtype `-k` xkb keysym name (best-effort, common keys).
+const WTYPE_KEYSYMS = {
+  command: 'Super_L', cmd: 'Super_L', meta: 'Super_L', super: 'Super_L', win: 'Super_L',
+  control: 'Control_L', ctrl: 'Control_L', option: 'Alt_L', alt: 'Alt_L',
+  shift: 'Shift_L', return: 'Return', enter: 'Return', tab: 'Tab', escape: 'Escape', esc: 'Escape',
+  space: 'space', backspace: 'BackSpace', delete: 'Delete', up: 'Up', down: 'Down',
+  left: 'Left', right: 'Right', home: 'Home', end: 'End', pageup: 'Prior', pagedown: 'Next',
+};
+const WTYPE_MODS = new Set(['Super_L', 'Control_L', 'Alt_L', 'Shift_L']);
+
+// ydotool 1.x click argument nibbles: 0x40=down, 0x80=up, 0xC0=down+up; +button.
+const YDO_BUTTON = { left: 0x00, right: 0x01, middle: 0x02 };
+
+function buildInput() {
+  async function tryRun(bin, args, opts) {
+    try { await run(bin, args, opts); return true; }
+    catch (e) { debug(`${bin} ${args.join(' ')} → ${e.message}`); return false; }
+  }
+
+  return {
+    /** moveMouse(x, y, _animate) — absolute, in the ydotool/native click space. */
+    async moveMouse(x, y, _animate) {
+      if (!TOOLS.ydotool) { debug('moveMouse no-op (ydotool absent)'); return; }
+      // ydotool 1.x: `mousemove -a -x X -y Y` (absolute).
+      await tryRun('ydotool', ['mousemove', '-a', '-x', String(Math.round(x)), '-y', String(Math.round(y))]);
+    },
+
+    /** mouseButton(button, action, count?) — action: "click"|"press"|"release". */
+    async mouseButton(button, action, count) {
+      if (!TOOLS.ydotool) { debug('mouseButton no-op (ydotool absent)'); return; }
+      const b = YDO_BUTTON[button] != null ? YDO_BUTTON[button] : 0x00;
+      let nibble;
+      if (action === 'press') nibble = 0x40;
+      else if (action === 'release') nibble = 0x80;
+      else nibble = 0xC0; // click (down+up)
+      const code = '0x' + (nibble | b).toString(16).toUpperCase().padStart(2, '0');
+      const n = Math.max(1, count || 1);
+      const args = ['click'];
+      if (n > 1) args.push('--repeat', String(n), '--next-delay', '40');
+      args.push(code);
+      await tryRun('ydotool', args);
+    },
+
+    /** mouseScroll(amount, dir) — dir: "vertical"|"horizontal". */
+    async mouseScroll(amount, dir) {
+      if (!TOOLS.ydotool) { debug('mouseScroll no-op (ydotool absent)'); return; }
+      const a = Math.round(amount) || 0;
+      if (a === 0) return;
+      // ydotool wheel: `mousemove -w -x H -y V`.
+      const args = dir === 'horizontal'
+        ? ['mousemove', '-w', '-x', String(a), '-y', '0']
+        : ['mousemove', '-w', '-x', '0', '-y', String(a)];
+      await tryRun('ydotool', args);
+    },
+
+    /** keys(arr) — chord, e.g. ["command","v"]. Prefer wtype (named keys). */
+    async keys(arr) {
+      const list = Array.isArray(arr) ? arr : [arr];
+      if (TOOLS.wtype) {
+        // Build: press modifiers (-M), tap last key (-k), release modifiers (-m).
+        const syms = list.map((k) => WTYPE_KEYSYMS[String(k).toLowerCase()] || k);
+        const mods = syms.filter((s) => WTYPE_MODS.has(s));
+        const keys = syms.filter((s) => !WTYPE_MODS.has(s));
+        const args = [];
+        for (const m of mods) args.push('-M', m);
+        for (const k of keys) args.push('-k', k);
+        for (const m of mods.reverse()) args.push('-m', m);
+        if (args.length) { await tryRun('wtype', args); return; }
+      }
+      debug(`keys no-op for [${list.join('+')}] (wtype absent or unmapped; ydotool keycode map is TODO)`);
+    },
+
+    /** key(name, action) — action: "press"|"release". Best-effort via wtype. */
+    async key(name, action) {
+      const sym = WTYPE_KEYSYMS[String(name).toLowerCase()] || name;
+      if (TOOLS.wtype) {
+        if (action === 'press') await tryRun('wtype', ['-P', sym]);
+        else if (action === 'release') await tryRun('wtype', ['-p', sym]);
+        else await tryRun('wtype', ['-k', sym]);
+        return;
+      }
+      debug(`key no-op for ${name}/${action} (wtype absent)`);
+    },
+
+    /** typeText(str) — Unicode text entry. ydotool primary, wtype fallback. */
+    async typeText(str) {
+      const text = String(str == null ? '' : str);
+      if (text.length === 0) return;
+      if (TOOLS.ydotool && await tryRun('ydotool', ['type', '--', text])) return;
+      if (TOOLS.wtype && await tryRun('wtype', [text])) return;
+      debug('typeText no-op (ydotool/wtype absent)');
+    },
+
+    /** mouseLocation() → {x,y}. Electron screen.getCursorScreenPoint(). */
+    mouseLocation() {
+      const e = electron();
+      try {
+        if (e && e.screen) { const p = e.screen.getCursorScreenPoint(); return { x: p.x, y: p.y }; }
+      } catch {}
+      return { x: 0, y: 0 };
+    },
+
+    /** getFrontmostAppInfo() → {bundleId,appName}|null. No model on Wayland. */
+    getFrontmostAppInfo() { return null; },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+module.exports = {
+  createComputerUse: buildComputerUse,
+  createInput: buildInput,
+  // exported for tests / future wiring
+  _internals: { coordSpace, describeDisplays, captureToContract, detectTool, TOOLS },
+};
+
+// ---------------------------------------------------------------------------
+// Self-test: `node stubs/computer-use-linux.js --selftest`
+// Validates the module loads, the namespace shape is complete, the coordinate
+// transform is consistent, and (if grim is present) a real capture round-trips.
+// ---------------------------------------------------------------------------
+if (require.main === module && process.argv.includes('--selftest')) {
+  (async () => {
+    let failures = 0;
+    const check = (name, cond) => { process.stdout.write(`${cond ? 'ok  ' : 'FAIL'} ${name}\n`); if (!cond) failures++; };
+
+    const cu = buildComputerUse();
+    check('computerUse.display.getSize is fn', typeof cu.display.getSize === 'function');
+    check('computerUse.display.listAll is fn', typeof cu.display.listAll === 'function');
+    check('computerUse.screenshot.captureExcluding is fn', typeof cu.screenshot.captureExcluding === 'function');
+    check('computerUse.screenshot.captureRegion is fn', typeof cu.screenshot.captureRegion === 'function');
+    check('computerUse.resolvePrepareCapture is fn', typeof cu.resolvePrepareCapture === 'function');
+    check('computerUse.tcc.checkAccessibility()===true', cu.tcc.checkAccessibility() === true);
+    check('computerUse.tcc.checkScreenRecording()===true', cu.tcc.checkScreenRecording() === true);
+    for (const m of ['prepareDisplay', 'previewHideSet', 'findWindowDisplays', 'appUnderPoint', 'listInstalled', 'iconDataUrl', 'listRunning', 'open', 'unhide']) {
+      check(`computerUse.apps.${m} is fn`, typeof cu.apps[m] === 'function');
+    }
+    check('apps.prepareDisplay shape', JSON.stringify(cu.apps.prepareDisplay()) === '{"activated":null,"hidden":[]}');
+    check('apps.listInstalled() === []', Array.isArray(cu.apps.listInstalled()) && cu.apps.listInstalled().length === 0);
+    check('unknown namespace member → no-op (no throw)', (() => { try { return cu.nope === undefined ? true : cu.nope() === undefined; } catch { return false; } })());
+
+    // coordSpace identity (v1)
+    const cs = coordSpace({ width: 2560, height: 1440, scaleFactor: 1, originX: 0, originY: 0 });
+    check('coordSpace pxWidth=2560', cs.pxWidth === 2560);
+    check('coordSpace pxHeight=1440', cs.pxHeight === 1440);
+    check('coordSpace forces scaleFactor=1', cs.scaleFactor === 1);
+
+    const input = buildInput();
+    for (const m of ['moveMouse', 'mouseButton', 'mouseScroll', 'keys', 'key', 'typeText', 'mouseLocation', 'getFrontmostAppInfo']) {
+      check(`input.${m} is fn`, typeof input[m] === 'function');
+    }
+
+    if (TOOLS.grim) {
+      try {
+        const display = { displayId: 0, width: 1920, height: 1080, scaleFactor: 1, originX: 0, originY: 0 };
+        const shot = await captureToContract(display, 1568, 882, 0.75, null);
+        const bytes = Buffer.from(shot.base64, 'base64').length;
+        check('live grim capture base64 non-empty', shot.base64.length > 0);
+        check('live capture decoded >= 1024 bytes (Lgt)', bytes >= 1024);
+        check('live capture reports displayWidth/Height', shot.displayWidth > 0 && shot.displayHeight > 0);
+        process.stdout.write(`     captured ${shot.width}x${shot.height} (display ${shot.displayWidth}x${shot.displayHeight}), ${bytes} bytes\n`);
+      } catch (e) {
+        check(`live grim capture (${e.message})`, false);
+      }
+    } else {
+      process.stdout.write('skip live capture (grim absent)\n');
+    }
+
+    process.stdout.write(failures === 0 ? '\nSELFTEST PASS\n' : `\nSELFTEST FAIL (${failures})\n`);
+    process.exit(failures === 0 ? 0 : 1);
+  })();
+}


### PR DESCRIPTION
## Summary

Adds an **experimental, default-off** Linux backend for Cowork "computer use". Gated behind **two** flags so `dev`/`main` with default env are byte-for-byte unchanged (`computerUse` stays `null`):

- **build:** `ENABLE_EXPERIMENTAL_PATCHES=1` stages the backend module next to the `@ant/claude-swift` stub
- **runtime:** `ENABLE_COMPUTER_USE=1` activates it

`COMPUTER_USE_RECON=1` is a runtime diagnostic that replaces `computerUse` with a logging Proxy (never touches the bundle).

## Phase 1 — interface recon (read-only)

The `computerUse` contract was reverse-engineered, not guessed (guessing it previously caused a SIGSEGV regression here):

- `patches/recon-computer-use.mjs` — acorn walk over `.vite/build` → `/tmp/cd-computeruse-recon.md` (Section 8 = authoritative method → args → return contract → frequency table).
- `COMPUTER_USE_RECON=1` logging Proxy in `stubs/claude-swift.js` (mirrors the existing `vm` Proxy): logs `seq | method | argc | args` and returns permissive stand-ins.

Two findings overrode the original spec text (followed the contract, not the guess):
- **Screenshots are JPEG, not PNG** — consumer hardcodes `mimeType:"image/jpeg"` and validates decoded length ≥ 1024 bytes (`Lgt`). The recon proxy returns a ≥1024-byte image so the orchestrator proceeds.
- **Input is not part of `computerUse`** — `moveMouse/click/keys/typeText/mouseScroll` live on `@ant/claude-native`; `computerUse` is `{display, screenshot, resolvePrepareCapture, tcc, apps}`.

## Phase 2 — implementation

`stubs/computer-use-linux.js`:
- `computerUse` namespace: `display.getSize/listAll`, `screenshot.captureExcluding/captureRegion`, `resolvePrepareCapture`, `tcc.*`, `apps.*`. Screenshots via **grim** + Electron `nativeImage` (resize/JPEG), matching the win32 path's return shape exactly.
- Input primitives (**ydotool** absolute pointer/click/scroll, **wtype** keyboard fallback) exported separately, since input belongs on `@ant/claude-native`.
- **ONE** centralized coordinate transform (`coordSpace`/`assumedScaleFactor`); v1 assumes a single output, scaleFactor 1, and warns loudly on fractional scaling rather than miscalibrating silently.
- Missing tools log once and degrade to no-ops; unidentified namespace methods are logging no-ops. Self-validates via `node stubs/computer-use-linux.js --selftest`.

Plus a **minimal gated staging hook** in `scripts/patch-cowork.sh` (node --check + copy, non-fatal) and Build-Flags docs in `README.md`/`CLAUDE.MD` listing the required packages (grim, ydotool+ydotoold, optional wtype) and the single-output / no-fractional-scaling caveat.

## ⚠️ Maintainer decision required (INVARIANTS.md)

Wiring `computerUse` is necessary but **not sufficient**. The stock bundle hard-gates Linux computer use in three places, intentionally **not** patched here:
1. `hBA = Set(["darwin","win32"])` → `ib()` false → tool reports "disabled";
2. executor dispatch `win32?createWin32Executor:createDarwinExecutor` — no Linux branch → throws at construction;
3. no Linux capability profile.

Lifting those requires AST patches in the SIGSEGV-prone minified zone and contradicts the ratified **"No Computer Use" non-goal in `INVARIANTS.md`** — `INVARIANTS.md` is deliberately left untouched; resolving that contradiction is a maintainer call.

## Validation

- `node --check` on all changed JS; `bash -n` on patch-cowork.sh — clean
- `--selftest` passes incl. a real 1920×1080 grim capture round-trip
- `validate-bundle.sh` confirms the JS bundle is untouched (16 files)
- All three modes verified: default → `null`; `COMPUTER_USE_RECON=1` → logging proxy; `ENABLE_COMPUTER_USE=1` → grim-backed namespace

## Test

```sh
# packages: grim (required), ydotool + running ydotoold w/ /dev/uinput access, optional wtype
ENABLE_EXPERIMENTAL_PATCHES=1 ./scripts/patch-cowork.sh   # stages the backend
# launch with ENABLE_COMPUTER_USE=1  (or COMPUTER_USE_RECON=1 to log the live call sequence)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)