### PR TITLE
docs: document computer-use backend + add Claude Code skills

### DIFF
--- a/.claude/skills/build-packages/SKILL.md
+++ b/.claude/skills/build-packages/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: build-packages
+description: Run the claude-desktop-linux build pipeline — fetch-and-extract, inject-stubs, patch-cowork, build-packages — to produce RPM/DEB/Pacman/Nix/AppImage from the macOS DMG. Use when asked to build the app, produce packages, do a full/clean build, rebuild after changing a stub or patch, or test that the pipeline still completes. Covers the idempotency guards, env vars (BUILD_DIR, SKIP_DOWNLOAD, COWORK_BACKEND, ENABLE_EXPERIMENTAL_PATCHES), and how to force a re-run of a single stage.
+---
+
+# Build the Linux packages
+
+Four scripts run in order; each is idempotent and writes a guard file under
+`$BUILD_DIR` (default `/tmp/claude-build`), so re-running resumes where the last
+run stopped. To force a stage to re-run, delete its guard.
+
+```sh
+./scripts/fetch-and-extract.sh   # download DMG, SHA256-verify, dmg2img + 7z, unpack app.asar,
+                                 # emit $BUILD_DIR/VERSION + ELECTRON_VERSION, extract icons
+./scripts/inject-stubs.sh        # replace @ant/claude-native + @ant/claude-swift with stubs/
+./scripts/patch-cowork.sh        # default-on AST patches + prepend CJS shims; unlocks Cowork UI
+./scripts/build-packages.sh      # re-pack app.asar once, then RPM + DEB + Pacman + Nix + AppImage → $OUTPUT_DIR
+```
+
+## Guards (delete to re-run a stage)
+
+| Stage | Guard file |
+|---|---|
+| fetch-and-extract | `$BUILD_DIR/.fetch-and-extract-done` |
+| inject-stubs | `$BUILD_DIR/.inject-stubs-done` (also re-runs automatically if `stubs/claude-native.js` or `stubs/claude-swift.js` changed — it hashes them) |
+| patch-cowork | `$BUILD_DIR/.patch-cowork-done` |
+
+`inject-stubs` only re-hashes `claude-native.js` and `claude-swift.js`. If you
+changed another staged file (e.g. `stubs/computer-use-linux.js`,
+`stubs/dispatch-polyfill.js`, `patches/*.js`), delete `.patch-cowork-done` and
+re-run `patch-cowork.sh`.
+
+## Env vars
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `BUILD_DIR` | `/tmp/claude-build` | Scratch dir + guard files |
+| `OUTPUT_DIR` | `./output` | Where packages land |
+| `SKIP_DOWNLOAD` | unset | `1` reuses the existing `$BUILD_DIR/claude.dmg` (skip the slow download) |
+| `COWORK_BACKEND` | `bubblewrap` | `bubblewrap` (sandbox) or `host` (no isolation) — runtime, not build |
+| `ELECTRON_OVERRIDE` | unset | Force a specific Electron version |
+| `ENABLE_EXPERIMENTAL_PATCHES` | unset | `1` additionally runs the experimental AST patches AND stages `stubs/computer-use-linux.js` (off by default — those AST patches can corrupt the bundle) |
+| `SKIP_COWORK_PATCH` | unset | `1` skips `patch-cowork.sh` entirely |
+
+## Verify without a full build
+
+- Syntax-gate every stub/patch: `node --check stubs/*.js` and `bash -n scripts/*.sh`.
+- After `patch-cowork.sh`, the bundle is acorn-validated inline and by
+  `./scripts/validate-bundle.sh` (runs acorn on every `.vite/build/*.js`). Run it
+  standalone to confirm no patch produced invalid JS.
+- A typical local loop: `SKIP_DOWNLOAD=1 ./scripts/fetch-and-extract.sh` then the
+  remaining three scripts.
+
+## Notes
+
+- Build dependencies (`dmg2img`, `7z`, `npx asar`, `rpmbuild`, `appimagetool`,
+  `icns2png`/`magick`) are resolved at runtime; scripts print install hints if missing.
+- The DMG is never cached — always fetched fresh and SHA256-verified.
+- CI runs the same four scripts on `ubuntu-latest` (`.github/workflows/build.yml`).
+- See `CLAUDE.MD` → "Build Phases" for the authoritative per-script breakdown.

--- a/.claude/skills/bundle-recon/SKILL.md
+++ b/.claude/skills/bundle-recon/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: bundle-recon
+description: Reverse-engineer a symbol, function, call site, or interface contract inside Claude Desktop's minified main-process bundle (.vite/build/index.js, ~13 MB single line) WITHOUT guessing. Use when you need to know how the app calls a stub method, what arguments/return shape a native namespace expects, where a feature is gated, or to resolve a minified identifier. Covers safe byte-range slicing, offset-printing, acorn AST walks (recon-*.mjs pattern), and the flag-gated runtime logging Proxy. Guessing a contract here has caused SIGSEGV regressions — establish ground truth.
+---
+
+# Recon a minified-bundle contract
+
+The main bundle is one ~13 MB line. Reading it whole overflows context and tools.
+Establish ground truth from definitions AND call sites — never guess (guessed
+shapes have caused SIGSEGV here).
+
+## 1. Locate before you read — print offsets
+
+```sh
+BUNDLE=/tmp/claude-build/app-extracted/.vite/build/index.js
+node -e 'const s=require("fs").readFileSync(process.env.BUNDLE,"utf8");
+const re=/PATTERN/g;let m,n=0;
+while((m=re.exec(s))&&n<60){console.log(m.index, JSON.stringify(s.slice(m.index-60,m.index+120)));n++}'
+```
+
+## 2. Read a region by byte range (never the whole file)
+
+```sh
+node -e 'const s=require("fs").readFileSync(process.env.BUNDLE,"utf8");process.stdout.write(s.slice(START,END))' | fold -w 200
+```
+
+Resolve a minified identifier (`dft`, `OIr`, `vE`, …) by reading its definition,
+then every call site. Follow aliases (`const x = A.namespace; x.method(...)`).
+
+## 3. Static AST recon (the recon-*.mjs pattern)
+
+For anything beyond a couple of sites, write a read-only acorn walker modeled on
+`patches/recon-dispatch-flags.mjs` / `patches/recon-computer-use.mjs`. Use the
+shared helpers in `patches/patch-utils.mjs` (`collectJsFiles`, `tryParse`,
+`createLogger`). Record, per call site: the full member chain, argument source
+text, await/destructuring (return-shape hints), and frequency. Emit a markdown
+report; do not modify the bundle.
+
+```sh
+node patches/recon-computer-use.mjs        # example: writes /tmp/cd-computeruse-recon.md
+```
+
+## 4. Runtime recon — a flag-gated logging Proxy
+
+When static reading can't reveal the live call sequence/payloads, install a
+logging Proxy in the relevant stub behind a NEW env flag (mirror the `vm` Proxy
+in `stubs/claude-swift.js`). It logs `method | argCount | args` and returns
+maximally permissive stand-ins so the orchestrator PROCEEDS, revealing which
+return shapes make it continue vs. error. Precedents:
+
+- `COMPUTER_USE_RECON=1` → logs `computerUse.*` calls to `/tmp/cd-computeruse-recon.md`.
+- `DISPATCH_DEBUG=1` → logs Dispatch IPC traffic.
+
+The proxy must be inert without its flag (default behaviour byte-for-byte unchanged).
+
+## Pitfalls
+
+- Stand-in images must satisfy any size/format validation the consumer applies
+  (e.g. the computer-use path rejects a screenshot whose decoded base64 is < 1024
+  bytes) — a 1×1 PNG can short-circuit the very flow you're trying to observe.
+- `index.js` may parse as ESM or script — `tryParse` tries both.
+- Capability/platform gates often live far from the methods they gate; search the
+  whole bundle, not just the local region.
+- A finding is "high confidence" only when you've read BOTH the definition and a
+  call site.

--- a/.claude/skills/bundle-recon/SKILL.md
+++ b/.claude/skills/bundle-recon/SKILL.md
@@ -12,7 +12,7 @@ shapes have caused SIGSEGV here).
 ## 1. Locate before you read — print offsets
 
 ```sh
-BUNDLE=/tmp/claude-build/app-extracted/.vite/build/index.js
+export BUNDLE=/tmp/claude-build/app-extracted/.vite/build/index.js   # export so child `node` sees it
 node -e 'const s=require("fs").readFileSync(process.env.BUNDLE,"utf8");
 const re=/PATTERN/g;let m,n=0;
 while((m=re.exec(s))&&n<60){console.log(m.index, JSON.stringify(s.slice(m.index-60,m.index+120)));n++}'

--- a/.claude/skills/computer-use-test/SKILL.md
+++ b/.claude/skills/computer-use-test/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: computer-use-test
+description: Exercise and diagnose the EXPERIMENTAL Linux computer-use backend (stubs/computer-use-linux.js) on a Wayland/wlroots compositor. Use when asked to test computer use, run the screenshot/grim path, check ydotool/wtype input, run the contract recon, verify the default-off gating, or debug why computerUse is null. Covers the two activation flags, the COMPUTER_USE_RECON diagnostic, the required packages (grim/ydotool+ydotoold/wtype), the --selftest, and the single-output / no-fractional-scaling v1 caveat.
+---
+
+# Test the Linux computer-use backend
+
+EXPERIMENTAL and **default off**. `computerUse` is `null` unless flags are set —
+that null is by design and means the feature is inert, not broken.
+
+## Flags
+
+- **Build:** `ENABLE_EXPERIMENTAL_PATCHES=1 ./scripts/patch-cowork.sh` stages
+  `stubs/computer-use-linux.js` next to the injected `@ant/claude-swift` stub.
+- **Runtime:** `ENABLE_COMPUTER_USE=1` activates the grim/ydotool backend.
+- **Diagnostic:** `COMPUTER_USE_RECON=1` replaces `computerUse` with a logging
+  Proxy that appends every live call (`seq | method | argc | args`) to
+  `/tmp/cd-computeruse-recon.md` and returns permissive stand-ins. Takes
+  precedence over `ENABLE_COMPUTER_USE` when both are set. Never touches the bundle.
+
+Both flags required for the real backend: the build presence (experimental
+patches) AND the runtime flag.
+
+## Required packages (Wayland/wlroots, e.g. niri, Sway, Hyprland)
+
+| Tool | Role | Missing → |
+|---|---|---|
+| `grim` | screenshots (wlr-screencopy) | screenshots become no-ops; **required** |
+| `ydotool` + running `ydotoold` (needs `/dev/uinput` access) | absolute pointer / click / scroll / type | input no-ops |
+| `wtype` | keyboard fallback (named keys/chords) | keyboard no-ops |
+
+Missing tools log once at load and degrade to no-ops — they never crash the app.
+
+## Fast checks (no full build)
+
+```sh
+node --check stubs/computer-use-linux.js
+node stubs/computer-use-linux.js --selftest   # namespace shape, coord transform,
+                                              # failure path, + a live grim capture if grim is present
+```
+
+Verify the three gating modes from the stub directly:
+
+```sh
+node -e 'console.log(require("./stubs/claude-swift.js").computerUse)'                 # → null (default)
+ENABLE_COMPUTER_USE=1 node -e 'console.log(typeof require("./stubs/claude-swift.js").computerUse.screenshot.captureExcluding)'  # → function
+COMPUTER_USE_RECON=1  node -e 'require("./stubs/claude-swift.js").computerUse.display.getSize(0)'  # appends a log line
+```
+
+## Live recon (reveal the real call sequence)
+
+Run the app (or a Cowork computer-use task) with `COMPUTER_USE_RECON=1` and read
+`/tmp/cd-computeruse-recon.md` (Section 7.live). Regenerate the static contract
+report any time with `node patches/recon-computer-use.mjs`.
+
+## Known limits (v1)
+
+- Targets a **single output, scaleFactor 1, no fractional scaling**. Multi-output
+  `-o` targeting and DIP↔px conversion are TODO; on a fractional-scaled display
+  the backend forces scaleFactor 1 and warns loudly — clicks will be miscalibrated.
+- Screenshots are JPEG (the consumer hardcodes `image/jpeg` and validates decoded
+  length ≥ 1024 bytes), not PNG.
+- **Not reachable end-to-end** in the stock bundle: Linux is hard-gated in three
+  places (`hBA` platform set; executor dispatch with no linux branch; capability
+  profiles). Lifting those is a maintainer decision tied to the `INVARIANTS.md`
+  "No Computer Use" non-goal. Full contract + rationale: `docs/computer-use-decision.md`.

--- a/.claude/skills/release-update/SKILL.md
+++ b/.claude/skills/release-update/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: release-update
+description: Adapt claude-desktop-linux to a new Claude Desktop release when a build breaks because the minified bundle changed shape. Use when find-platform-gate.mjs (or another AST patch) exits non-zero on a new version, when "could not find the platform gate" / pattern-not-found errors appear, when bumping to a newer upstream DMG, or when a stub method that used to work now logs "MISSING METHOD". Walks the diagnosis: dump AST candidates, locate the new function/symbol shape, update the pattern, re-validate.
+---
+
+# Update after a new Claude Desktop release
+
+The patches key off the *shape* of minified functions, not their names (the
+minifier renames every release). When upstream changes that shape, a patch's
+`find-*.mjs` exits non-zero — **do not suppress it**; update the pattern.
+
+## 1. Identify what broke
+
+A failing `patch-cowork.sh` names the script that exited non-zero. The common one:
+
+```sh
+node patches/find-platform-gate.mjs --dump-candidates
+```
+
+This prints every function that partially matches the platform-gate shape
+(reads `process.platform`, compares to `"darwin"`/`"win32"`, returns a
+`{status:...}` object).
+
+## 2. Locate the new shape (minified bundle is one ~13 MB line)
+
+NEVER open `.vite/build/index.js` with a whole-file read. Slice byte ranges and
+print offsets first (see the `bundle-recon` skill for the full technique):
+
+```sh
+BUNDLE=/tmp/claude-build/app-extracted/.vite/build/index.js
+# find candidate strings/symbols
+node -e 'const s=require("fs").readFileSync(process.env.BUNDLE,"utf8");const re=/process\.platform/g;let m,n=0;while((m=re.exec(s))&&n<40){console.log(m.index,JSON.stringify(s.slice(m.index-50,m.index+80)));n++}'
+# read a region once you have an offset
+node -e 'const s=require("fs").readFileSync(process.env.BUNDLE,"utf8");process.stdout.write(s.slice(START,END))'
+```
+
+## 3. Update the pattern
+
+Edit the matching `patches/find-*.mjs` (e.g. `find-platform-gate.mjs`,
+`find-ccd-platform.mjs`, `find-vm-download.mjs`) so its acorn predicate matches
+the new shape. Keep it shape-based (structure of the AST), not name-based.
+
+## 4. Re-validate
+
+```sh
+rm -f /tmp/claude-build/.patch-cowork-done
+./scripts/patch-cowork.sh        # must exit 0
+./scripts/validate-bundle.sh     # acorn-checks every .vite/build/*.js
+```
+
+Then a full rebuild (`build-packages` skill) and a headless launch check.
+
+## Reference
+
+- `CLAUDE.MD` → "Updating After a Claude Desktop Release" and "Cowork Platform Gate".
+- Default-on patches must keep `main` green — fix them in place; do not feature-flag
+  them off.
+- Bump the pinned version in `nix/stable.json` / `nix/dev.json` only via the CI
+  release flow; `check-update.yml` polls the CDN every 6 h and dispatches `build.yml`.
+- If a stub method newly logs `MISSING METHOD` / `unknown property`, the
+  orchestrator started calling a method the stub doesn't implement — add it to
+  `stubs/claude-swift.js` (vm interface) or `stubs/claude-native.js`, matching the
+  contract before guessing (see `bundle-recon`).

--- a/.claude/skills/release-update/SKILL.md
+++ b/.claude/skills/release-update/SKILL.md
@@ -11,10 +11,13 @@ minifier renames every release). When upstream changes that shape, a patch's
 
 ## 1. Identify what broke
 
-A failing `patch-cowork.sh` names the script that exited non-zero. The common one:
+A failing `patch-cowork.sh` names the script that exited non-zero. The common one
+requires the extracted-bundle dir as a positional arg (the same one
+`patch-cowork.sh` passes as `$VITE_BUILD_DIR`/`$APP_DIR`); without it the script
+exits 1 with a usage error:
 
 ```sh
-node patches/find-platform-gate.mjs --dump-candidates
+node patches/find-platform-gate.mjs "${BUILD_DIR:-/tmp/claude-build}/app-extracted" --dump-candidates
 ```
 
 This prints every function that partially matches the platform-gate shape
@@ -27,7 +30,7 @@ NEVER open `.vite/build/index.js` with a whole-file read. Slice byte ranges and
 print offsets first (see the `bundle-recon` skill for the full technique):
 
 ```sh
-BUNDLE=/tmp/claude-build/app-extracted/.vite/build/index.js
+export BUNDLE=/tmp/claude-build/app-extracted/.vite/build/index.js   # export so child `node` sees it
 # find candidate strings/symbols
 node -e 'const s=require("fs").readFileSync(process.env.BUNDLE,"utf8");const re=/process\.platform/g;let m,n=0;while((m=re.exec(s))&&n<40){console.log(m.index,JSON.stringify(s.slice(m.index-50,m.index+80)));n++}'
 # read a region once you have an offset

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,8 @@ node_modules/
 *.img
 *.dmg
 build/
-.claude
+
+# Claude Code: ignore personal/local config (settings.local.json, caches),
+# but track shared, checked-in skills under .claude/skills/.
+.claude/*
+!.claude/skills/

--- a/ARCHITECTURE.MD
+++ b/ARCHITECTURE.MD
@@ -333,6 +333,62 @@ platform gate (separate from the Cowork gate).
 
 ---
 
+## Computer Use on Linux
+
+**Experimental, disabled by default.** A Wayland backend exists but does not
+activate without two explicit flags, and is not reachable end-to-end on the
+stock bundle. Full contract and rationale: `docs/computer-use-decision.md`.
+
+### Two native surfaces
+
+"Computer use" is backed by two different native surfaces on macOS/Windows, and
+the Linux backend (`stubs/computer-use-linux.js`) mirrors both:
+
+- `@ant/claude-swift` `.computerUse` — display enumeration, screenshots, and app
+  metadata. The Linux implementation uses `grim` (wlr-screencopy) for capture
+  and Electron `nativeImage` to resize/JPEG-encode, matching the Windows
+  executor's `desktopCapturer` → `nativeImage.resize().toJPEG()` shape. Screenshots
+  return JPEG (the consumer hardcodes `image/jpeg` and validates decoded length
+  ≥ 1024 bytes), not PNG.
+- `@ant/claude-native` — mouse/keyboard. The Linux input primitives use `ydotool`
+  (absolute pointer, click, scroll, type; needs a running `ydotoold` with
+  `/dev/uinput` access) with `wtype` as the keyboard fallback. They are exported
+  separately (`createInput()`) — input is **not** a member of `computerUse`, so
+  placing it there would contradict the interface — and are not wired by the
+  current change.
+
+### Contract established by recon, not guessing
+
+Guessing this contract previously caused a SIGSEGV regression, so it was
+reverse-engineered read-only: `patches/recon-computer-use.mjs` (static acorn
+walk) plus a runtime logging Proxy behind `COMPUTER_USE_RECON=1`, both writing to
+`/tmp/cd-computeruse-recon.md`. Unidentified namespace methods resolve to logged
+no-ops via a Proxy, and missing tools (`grim`/`ydotool`/`wtype`) log once and
+degrade to no-ops rather than crashing.
+
+### One coordinate transform
+
+The orchestrator converts model coordinates (in downsampled screenshot-image
+pixels) to clicks as `round(modelX * displayWidth / width) + originX` and passes
+the result untransformed to the input backend. So the screenshot's
+`{displayWidth, displayHeight, originX, originY}` and `display.getSize()` must be
+in the same space `ydotool`'s absolute pointer consumes. This mapping lives in a
+single function (`coordSpace()`); v1 assumes a single output, scaleFactor 1,
+origin (0,0) — and warns loudly on fractional scaling rather than miscalibrating.
+Multi-output and DIP↔px conversion are TODO.
+
+### Why it is not end-to-end
+
+The stock bundle hard-gates Linux computer use in three independent places: the
+platform allow-list (`new Set(["darwin","win32"])`), the executor-factory
+dispatch (`win32 ? createWin32Executor : createDarwinExecutor` — no Linux branch,
+so Linux throws at construction), and the absence of a Linux capability profile.
+Lifting these needs AST patches in the minified bundle and revisits the
+`INVARIANTS.md` "No Computer Use" non-goal — a maintainer decision, intentionally
+out of scope. `INVARIANTS.md` is not edited.
+
+---
+
 ## Package Format Decisions
 
 ### RPM: system Electron, no bundle
@@ -442,6 +498,14 @@ platform gates are bypassed, and IPC handlers are stubbed.  The
 management requires.  Background delivery (APNs/FCM push wake-up) is not
 available — tasks sent from mobile when the app is closed won't arrive until the
 next launch.  See "Dispatch on Linux" section above for details.
+
+**Computer Use — experimental, default off, not end-to-end.** A Wayland backend
+(`stubs/computer-use-linux.js`: `grim` + `ydotool`/`wtype`) is staged under
+`ENABLE_EXPERIMENTAL_PATCHES=1` and activated by `ENABLE_COMPUTER_USE=1`; with
+neither, `computerUse` is `null` and behaviour is unchanged.  The stock bundle
+still hard-gates Linux in three places, so it is not reachable end-to-end —
+lifting that revisits the ratified "No Computer Use" non-goal and is a maintainer
+decision.  See "Computer Use on Linux" above and `docs/computer-use-decision.md`.
 
 ## Explicit Non-Goals
 

--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -82,6 +82,16 @@ entirely and run the Claude Code binary directly on the host.
         └── smoke-test.yml              ← smoke tests (syntax, RPM install, headless launch)
 ```
 
+## Claude Code Skills
+
+Repeatable workflows for this repo live in `.claude/skills/<name>/SKILL.md` and
+are auto-discovered by Claude Code:
+
+- `build-packages` — the fetch → inject → patch → build pipeline, guards, env vars.
+- `release-update` — adapt to a new Claude Desktop release when an AST pattern stops matching.
+- `bundle-recon` — reverse-engineer a symbol/contract in the minified bundle without guessing.
+- `computer-use-test` — exercise/diagnose the experimental Linux computer-use backend.
+
 ## Invariants — Never Break These
 
 Invariants and non-goals are defined in INVARIANTS.md (change-protected, see .github/workflows/invariant-guard.yml).

--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -516,7 +516,8 @@ Invariants and non-goals are defined in INVARIANTS.md (change-protected, see .gi
 
 When `find-platform-gate.mjs` exits 1 on a new version:
 
-1. Run `node patches/find-platform-gate.mjs --dump-candidates` to print all
+1. Run `node patches/find-platform-gate.mjs "$BUILD_DIR/app-extracted" --dump-candidates`
+   (the extracted-bundle dir is a required positional arg) to print all
    functions that partially match.
 2. Inspect the candidates and identify the new gate function shape.
 3. Update the AST pattern in `find-platform-gate.mjs`.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ See [ARCHITECTURE.MD](ARCHITECTURE.MD) for design decisions and trade-offs.
   (see the `fix_cowork` branch). Default builds only patch the platform
   gate so the Cowork UI renders; the socket transport and ComputerUseTcc
   AST injections that wire it end-to-end stay off.
+- **Computer Use** — experimental, disabled by default. A Wayland backend
+  (`stubs/computer-use-linux.js`: `grim` screenshots + `ydotool`/`wtype`
+  input) is staged under `ENABLE_EXPERIMENTAL_PATCHES=1` and activated at
+  runtime by `ENABLE_COMPUTER_USE=1`; with neither, `computerUse` stays
+  `null` and nothing changes. It is **not** wired end-to-end — the stock
+  bundle still hard-gates Linux computer use, which is a maintainer
+  decision tied to the `INVARIANTS.md` "No Computer Use" non-goal. See
+  [Build Flags](#build-flags) and [docs/computer-use-decision.md](docs/computer-use-decision.md).
 - **Dispatch (default builds)** — the Dispatch availability gate is
   patched (`patches/fix-dispatch-gate.mjs`) and renderer IPC handlers are
   stubbed (`stubs/dispatch-polyfill.js`), but GrowthBook feature flags
@@ -55,7 +63,8 @@ See [ARCHITECTURE.MD](ARCHITECTURE.MD) for design decisions and trade-offs.
 |---|---|
 | **Dispatch (default builds)** | Availability gate is patched (`patches/fix-dispatch-gate.mjs`) and renderer IPC handlers are stubbed (`stubs/dispatch-polyfill.js`), so the UI renders, but GrowthBook feature flags are not overridden in default builds — `patches/patch-dispatch.mjs` is experimental (see [Build Flags](#build-flags)). |
 | **Dispatch (experimental, `ENABLE_EXPERIMENTAL_PATCHES=1`)** | Adds the GrowthBook override (`patches/patch-dispatch.mjs`). Even with the flag set, background delivery (APNs/FCM push) is unavailable, so tasks sent from mobile while the app is closed never arrive — this depends on platform features Linux does not provide and is not gated by an env var. |
-| **Computer Use** | macOS implementation uses `AXUIElement`; an `xdotool`/`scrot` replacement would be fragile across desktop environments |
+| **Computer Use (default builds)** | `computerUse` is `null`; not enabled. The macOS implementation uses `AXUIElement`. |
+| **Computer Use (experimental, `ENABLE_EXPERIMENTAL_PATCHES=1` + `ENABLE_COMPUTER_USE=1`)** | A Wayland backend exists (`stubs/computer-use-linux.js`: `grim` + `ydotool`/`wtype`) but is **not** reachable end-to-end — the stock bundle hard-gates Linux in three places (platform allow-list, executor dispatch, capability profiles), and lifting them touches the ratified "No Computer Use" non-goal (`INVARIANTS.md`), so it is a maintainer decision. v1 also assumes a single output with no fractional scaling. See [docs/computer-use-decision.md](docs/computer-use-decision.md). |
 | **ARM64** | Electron binary selection and AppImage build are x86_64 only; ARM64 is a future milestone |
 
 ---

--- a/docs/computer-use-decision.md
+++ b/docs/computer-use-decision.md
@@ -1,0 +1,159 @@
+# Decision memo: experimental Linux computer-use backend
+
+This memo documents `stubs/computer-use-linux.js` and its gated wiring, added
+in PR #96 (`feat(cowork): EXPERIMENTAL Linux computer-use backend`). It answers,
+in order:
+
+1. What the backend does and how it is gated.
+2. How its contract was established (no guessing).
+3. The verified `computerUse` contract it implements.
+4. The single correctness risk — coordinate space.
+5. Why it is **not** reachable end-to-end on the stock bundle.
+6. The `INVARIANTS.md` "No Computer Use" tension and three options for the maintainer.
+
+The default build is unchanged by this work: with no flags, `computerUse` stays
+`null` exactly as before.
+
+---
+
+## Phase 1 — What the backend does
+
+`stubs/computer-use-linux.js` provides a Linux implementation of the
+`@ant/claude-swift` `computerUse` namespace that the Cowork orchestrator consumes
+for "computer use":
+
+- **Screenshots** via `grim` (wlr-screencopy) → resized and JPEG-encoded with
+  Electron `nativeImage`, mirroring the Windows executor's
+  `nativeImage.resize().toJPEG()` path.
+- **Display enumeration** via Electron's `screen` API (the same source the
+  Windows path uses for display rects).
+- **Input primitives** (`moveMouse`/`mouseButton`/`mouseScroll`/`keys`/`key`/
+  `typeText`) via `ydotool` (absolute pointer + click + scroll + type) with
+  `wtype` as the keyboard fallback. These are **exported separately**
+  (`createInput()`), not placed on the `computerUse` object — see §3.
+
+### Gating (two flags, default off)
+
+| Flag | Time | Effect |
+|---|---|---|
+| `ENABLE_EXPERIMENTAL_PATCHES=1` | build | `scripts/patch-cowork.sh` stages `computer-use-linux.js` next to the injected `@ant/claude-swift` stub (a `node --check`'d copy; non-fatal). |
+| `ENABLE_COMPUTER_USE=1` | runtime | `stubs/claude-swift.js` `require()`s the staged module and sets `computerUse` to the grim/ydotool backend. |
+| `COMPUTER_USE_RECON=1` | runtime | `stubs/claude-swift.js` installs a logging Proxy instead (diagnostic; see §2). Precedence over `ENABLE_COMPUTER_USE`. |
+
+Both real-backend flags are required: the build flag controls the module's
+*presence*, the runtime flag controls *activation*. With neither, the runtime
+`require()` is never attempted and `computerUse` is `null`.
+
+## Phase 2 — How the contract was established (no guessing)
+
+Guessing this contract previously caused a SIGSEGV regression, so the interface
+was reverse-engineered read-only before any backend was written:
+
+- **Static:** `patches/recon-computer-use.mjs` (acorn walk over `.vite/build`)
+  → `/tmp/cd-computeruse-recon.md`, recording every `computerUse`-namespace
+  access, argument shapes, and return-consumption per call site.
+- **Runtime:** the `COMPUTER_USE_RECON=1` logging Proxy records the live call
+  sequence and returns permissive stand-ins (including a ≥1024-byte image — a
+  1×1 PNG would fail the consumer's decoded-length check and short-circuit the
+  flow it is meant to observe).
+- Findings were cross-referenced between the macOS executor (`createDarwinExecutor`)
+  and the Windows executor (`createWin32Executor`, which uses Electron
+  `desktopCapturer`/`nativeImage` — the closest analog to a Linux backend) and
+  adversarially re-derived.
+
+`/tmp/cd-computeruse-recon.md` (Section 8) is the authoritative synthesis. That
+path is in `/tmp` and ephemeral; regenerate the static portion with
+`node patches/recon-computer-use.mjs`.
+
+## Phase 3 — The verified `computerUse` contract
+
+The namespace the backend implements (quality literal `0.75` = JPEG quality;
+target dims are pre-capped to ≤1568 px / ≤1568 image-tiles by the caller):
+
+| Method | Returns (consumed fields) |
+|---|---|
+| `display.getSize(displayId)` | `{width, height, scaleFactor, originX, originY}` |
+| `display.listAll()` | `[{displayId, width, height, scaleFactor, originX, originY, isPrimary, label}]` |
+| `screenshot.captureExcluding(allowed, 0.75, w, h, displayId)` | `{base64, width, height, displayWidth, displayHeight, displayId, originX, originY}` — base64 is **JPEG**, decoded length must be ≥ 1024 |
+| `screenshot.captureRegion(allowed, x, y, w, h, w2, h2, 0.75, displayId)` | `{base64}` (only `.base64` consumed; x/y/w/h in logical points) |
+| `resolvePrepareCapture(allowed, host, 0.75, w, h, prefId, autoResolve, doHide)` | the screenshot shape **plus** `{hidden:[], activated}`; on failure `{captureError, …zeros}` |
+| `tcc.checkAccessibility()` / `tcc.checkScreenRecording()` | `boolean` — both must be true for `ensureOsPermissions` to grant on non-Windows |
+| `apps.*` | `prepareDisplay`→`{activated, hidden}`, list/preview→`[]`, `appUnderPoint`/`iconDataUrl`→`null`, `open`/`unhide`→void |
+
+All capture methods return the graceful `captureError` shape on `grim`
+missing/failure rather than rejecting (PR #97), consistent with "missing tools
+degrade to a no-op." Unidentified namespace members resolve to logged no-ops via
+a Proxy, so an upstream addition can't throw.
+
+**Input lives on a different surface.** `moveMouse`/`mouseButton`/`keys`/
+`typeText`/`mouseScroll` are members of `@ant/claude-native`, **not** of
+`computerUse`. Putting them on `computerUse` would contradict the recon, so
+`createInput()` is exported for a deliberate future wiring into
+`stubs/claude-native.js` and is **not** wired by this change.
+
+## Phase 4 — Coordinate space (the single correctness risk)
+
+The orchestrator's converter maps model coordinates (in the downsampled
+screenshot-image pixel space) to click coordinates as:
+
+```
+clickX = round(modelX * screenshot.displayWidth / screenshot.width) + screenshot.originX
+```
+
+and passes the result **untransformed** to the input backend. So the one
+invariant a Linux backend must hold:
+
+> `screenshot.{displayWidth, displayHeight, originX, originY}` (and
+> `display.getSize().{width, height, scaleFactor, originX, originY}`) must be in
+> the **same coordinate space** that `ydotool`'s absolute pointer consumes.
+
+This mapping is centralized in **one** function (`coordSpace()` /
+`assumedScaleFactor()`). v1 assumes a **single output, scaleFactor 1, origin
+(0,0)** — then native px == logical px == ydotool absolute px and the transform
+is the identity. If the compositor reports fractional scaling the backend forces
+1 and warns loudly rather than silently miscalibrating. Multi-output offsets and
+DIP↔px conversion are TODO.
+
+## Phase 5 — Why it is not reachable end-to-end
+
+Wiring `computerUse` is necessary but **not sufficient**. The stock bundle
+hard-gates Linux computer use in three independent places:
+
+1. `hBA = new Set(["darwin","win32"])` — the platform allow-list. `ib()` (the
+   master enable) returns `false` unconditionally on Linux, so the tool handler
+   reports "Computer control is disabled" before any executor call.
+2. The executor factory builds eagerly via
+   `process.platform === "win32" ? createWin32Executor : createDarwinExecutor` —
+   no Linux branch, so Linux falls into `createDarwinExecutor`, which **throws**
+   at construction.
+3. No Linux capability profile (only `darwin`/`win32`).
+
+Lifting these requires AST patches in the SIGSEGV-prone minified bundle (add
+`"linux"` to the platform set; add a Linux executor branch that pairs the
+grim-backed screenshot with the `ydotool` input).
+
+## Phase 6 — INVARIANTS tension and maintainer options
+
+`INVARIANTS.md` records **"No Computer Use"** as a non-goal ("Requires
+`xdotool`/`scrot` hacks that are fragile and version-sensitive. Out of scope for
+the initial release."). This backend uses `grim`/`ydotool` (the Wayland
+equivalents) and intentionally does **not** edit `INVARIANTS.md` — that file is
+change-protected and resolving the contradiction is a maintainer call.
+
+Options:
+
+1. **Keep as-is (recommended for now).** The backend ships as inert,
+   default-off infrastructure + recon. `INVARIANTS.md` stays authoritative
+   ("No Computer Use"); nothing activates without two explicit flags *and* the
+   still-missing bundle patches. Lowest risk; documents the path for a later
+   decision.
+2. **Ratify computer use as an experimental goal.** Amend `INVARIANTS.md` to
+   carve out an experimental, default-off exception, then add the three bundle
+   patches (gated like the other experimental AST patches) to make it reachable
+   end-to-end. Larger surface; revisits a ratified non-goal.
+3. **Revert.** If "No Computer Use" is to remain absolute, drop the backend and
+   keep only the recon (`patches/recon-computer-use.mjs` + the report) as
+   reference. (PR #96 already has a `revert-96-…` branch on origin.)
+
+No option is applied here; this memo exists so the maintainer can decide with the
+full contract and risk in view.


### PR DESCRIPTION
Documentation + skills follow-up to the experimental Linux computer-use backend (#96, #97).

## Docs (the feature was only in README → Build Flags + CLAUDE.MD)

- **README** — a Features bullet, and split the "What Is NOT Supported" Computer Use row into *default* (`computerUse` null, not enabled) vs *experimental* (backend exists but not end-to-end), pointing at Build Flags and the new memo.
- **ARCHITECTURE.MD** — new **"Computer Use on Linux"** section: the two native surfaces (`@ant/claude-swift` screenshots via grim/nativeImage; `@ant/claude-native` input via ydotool/wtype), contract-by-recon, the single centralized coordinate transform, and the three bundle blockers that keep it from being end-to-end. Plus a Partial Support summary entry.
- **docs/computer-use-decision.md** — decision memo (same style as `platform-headers-decision.md`): gating, how the contract was established, the verified contract table, the coordinate invariant, why it is not reachable end-to-end, and the `INVARIANTS.md` "No Computer Use" tension with three maintainer options. **`INVARIANTS.md` is not edited.**

## Claude Code skills (`.claude/skills/<name>/SKILL.md`)

Repeatable workflows for this repo, auto-discovered by Claude Code:

| Skill | When it triggers |
|---|---|
| `build-packages` | build the app / produce packages / rebuild after a stub/patch change |
| `release-update` | an AST pattern stops matching a new Claude Desktop release |
| `bundle-recon` | reverse-engineer a symbol/contract in the minified bundle without guessing |
| `computer-use-test` | exercise/diagnose the experimental computer-use backend |

## .gitignore

Narrowed `.claude` → `.claude/*` + `!.claude/skills/` so **shared** skills are tracked while the **personal** `settings.local.json` (machine-absolute paths) stays ignored. Added a short skills index to CLAUDE.MD.

## Scope

Docs + skills only — no code, scripts, or `INVARIANTS.md` touched. Skill frontmatter validated (name matches dir, description present); cross-reference links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)