### PR TITLE
fix(packaging): taskbar icon — match StartupWMClass to the window's real app_id ("claude")

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -302,11 +302,13 @@ if [ -z "\$CLAUDE_CODE_LOCAL_BINARY" ]; then
   done
 fi
 
-# --class= pins the Wayland app_id (and X11 WM_CLASS under XWayland)
-# to "claude-desktop". We exec nixpkgs' electron binary directly, so
-# without this the app_id defaults to "electron" — which doesn't match
-# claude-desktop.desktop, and compositors like Niri can't resolve the
-# window to its Icon= entry, leaving the icon blank.
+# --class requests a Wayland app_id / X11 WM_CLASS. We exec nixpkgs'
+# electron binary directly, so without it the app_id would default to
+# "electron". NOTE: the upstream app overrides this at runtime and sets the
+# app_id from its product name → "claude" (verified via `niri msg windows`),
+# so the window reports "claude" regardless of --class. We pass "claude" here
+# to match that observed value and StartupWMClass=claude in claude-desktop.desktop,
+# so compositors/taskbars (e.g. Niri) can map the window to its Icon= entry.
 WAYLAND_FLAGS=""
 if [ -n "\$WAYLAND_DISPLAY" ] && [ -z "\$ELECTRON_OZONE_PLATFORM_HINT" ]; then
   WAYLAND_FLAGS="--enable-features=UseOzonePlatform,WaylandWindowDecorations --ozone-platform=wayland"
@@ -324,7 +326,7 @@ fi
 # (isEncryptionAvailable() → false), i.e. no worse than the current state.
 SAFESTORAGE_FLAGS="--password-store=gnome-libsecret"
 
-exec "${electronBin}" --class=claude-desktop \$WAYLAND_FLAGS \$SAFESTORAGE_FLAGS --no-sandbox "$out/lib/claude-desktop/app" "\$@"
+exec "${electronBin}" --class=claude \$WAYLAND_FLAGS \$SAFESTORAGE_FLAGS --no-sandbox "$out/lib/claude-desktop/app" "\$@"
 LAUNCHER
                 chmod +x $out/bin/claude-desktop
               '' else ''

--- a/flake.nix
+++ b/flake.nix
@@ -305,7 +305,7 @@ fi
 # --class requests a Wayland app_id / X11 WM_CLASS. We exec nixpkgs'
 # electron binary directly, so without it the app_id would default to
 # "electron". NOTE: the upstream app overrides this at runtime and sets the
-# app_id from its product name → "claude" (verified via `niri msg windows`),
+# app_id from its product name → "claude" (verify with: niri msg windows),
 # so the window reports "claude" regardless of --class. We pass "claude" here
 # to match that observed value and StartupWMClass=claude in claude-desktop.desktop,
 # so compositors/taskbars (e.g. Niri) can map the window to its Icon= entry.

--- a/flake.nix
+++ b/flake.nix
@@ -302,13 +302,14 @@ if [ -z "\$CLAUDE_CODE_LOCAL_BINARY" ]; then
   done
 fi
 
-# --class requests a Wayland app_id / X11 WM_CLASS. We exec nixpkgs'
-# electron binary directly, so without it the app_id would default to
-# "electron". NOTE: the upstream app overrides this at runtime and sets the
-# app_id from its product name → "claude" (verify with: niri msg windows),
-# so the window reports "claude" regardless of --class. We pass "claude" here
-# to match that observed value and StartupWMClass=claude in claude-desktop.desktop,
-# so compositors/taskbars (e.g. Niri) can map the window to its Icon= entry.
+# --class requests a Wayland app_id / X11 WM_CLASS. We exec nixpkgs' electron
+# directly, so without it the app_id would default to "electron". NOTE: the
+# upstream app overrides --class at runtime and reports app_id "claude" (from its
+# product name; verify with: niri msg windows). On native Wayland the window's
+# app_id is the primary key a shell matches to a desktop entry (StartupWMClass is
+# the X11 WM_CLASS key, also honored by bars like waybar's wlr/taskbar). We pass
+# "claude" to match the observed app_id and the StartupWMClass=claude in
+# claude-desktop.desktop, so the taskbar resolves the window to its Icon= entry.
 WAYLAND_FLAGS=""
 if [ -n "\$WAYLAND_DISPLAY" ] && [ -z "\$ELECTRON_OZONE_PLATFORM_HINT" ]; then
   WAYLAND_FLAGS="--enable-features=UseOzonePlatform,WaylandWindowDecorations --ozone-platform=wayland"

--- a/packaging/AppDir/claude-desktop.desktop
+++ b/packaging/AppDir/claude-desktop.desktop
@@ -7,8 +7,11 @@ Icon=claude-desktop
 Terminal=false
 Categories=Office;Network;
 MimeType=x-scheme-handler/claude;
-# Must equal the Wayland app_id / X11 WM_CLASS the window actually reports.
-# The upstream app sets it from its product name → "claude" (NOT "claude-desktop"),
-# overriding the launcher's --class, so the taskbar/window-list maps a window to
-# this entry (and its Icon=) only when this is "claude". Verify with: niri msg windows.
+# StartupWMClass is the X11 WM_CLASS match key (also used under XWayland). On
+# native Wayland the window's app_id is the primary key — ideally it equals the
+# desktop file ID — but waybar's wlr/taskbar and similar bars also match against
+# StartupWMClass. This window reports app_id / WM_CLASS "claude" (the upstream app
+# derives it from its product name and overrides the launcher's --class; check
+# with: niri msg windows), so set it to "claude" so the window resolves to this
+# entry and its Icon=.
 StartupWMClass=claude

--- a/packaging/AppDir/claude-desktop.desktop
+++ b/packaging/AppDir/claude-desktop.desktop
@@ -7,4 +7,8 @@ Icon=claude-desktop
 Terminal=false
 Categories=Office;Network;
 MimeType=x-scheme-handler/claude;
-StartupWMClass=claude-desktop
+# Must equal the Wayland app_id / X11 WM_CLASS the window actually reports.
+# The upstream app sets it from its product name → "claude" (NOT "claude-desktop"),
+# overriding the launcher's --class, so the taskbar/window-list maps a window to
+# this entry (and its Icon=) only when this is "claude". Verify with: niri msg windows.
+StartupWMClass=claude

--- a/patches/open-url-bridge.js
+++ b/patches/open-url-bridge.js
@@ -56,8 +56,10 @@ if (!global[INIT_SYM] && process.type === 'browser') {
           'Categories=Network;',
           'Icon=claude-desktop',
           'MimeType=x-scheme-handler/claude;',
-          // Must equal the app_id the window reports (product name → "claude"),
-          // so the taskbar/window-list can map the window to this entry + Icon.
+          // StartupWMClass is the X11 WM_CLASS match key (and is also consulted by
+          // Wayland bars like waybar's wlr/taskbar). The window reports app_id /
+          // WM_CLASS "claude" (product name; overrides --class), so set it to
+          // "claude" so the window maps to this entry + Icon.
           'StartupWMClass=claude',
           '',
         ].join('\n');

--- a/patches/open-url-bridge.js
+++ b/patches/open-url-bridge.js
@@ -54,8 +54,11 @@ if (!global[INIT_SYM] && process.type === 'browser') {
           'Terminal=false',
           'Type=Application',
           'Categories=Network;',
+          'Icon=claude-desktop',
           'MimeType=x-scheme-handler/claude;',
-          'StartupWMClass=Claude',
+          // Must equal the app_id the window reports (product name → "claude"),
+          // so the taskbar/window-list can map the window to this entry + Icon.
+          'StartupWMClass=claude',
           '',
         ].join('\n');
 


### PR DESCRIPTION
## Problem

Claude Desktop has **no icon in the taskbar / window-list** on Wayland (reported on niri). A taskbar resolves a window's icon by mapping its `app_id` → an installed `.desktop` entry (by basename or `StartupWMClass`) → `Icon=`. That mapping was broken.

## Root cause (diagnosed live)

`niri msg windows` reports the Claude window's **App ID as `claude`**, but:

- `packaging/AppDir/claude-desktop.desktop` declared `StartupWMClass=claude-desktop`
- `patches/open-url-bridge.js` (AppImage runtime writer) wrote `StartupWMClass=Claude` (and **no `Icon=`** at all)
- `flake.nix` launches with `--class=claude-desktop` and a comment claiming this pins the app_id

None of those match the observed `claude`. The launcher's `--class=claude-desktop` is **overridden at runtime** by the upstream app, which derives the Wayland `app_id` from its product name → `claude`. So no entry matched the window, and the icon (which *is* installed and on `XDG_DATA_DIRS`) was never consulted. This is an app/packaging issue, not a compositor bug — niri correctly reports `claude` and correctly finds no matching entry.

## Fix

Align everything to the value the window actually reports, `claude`:

- **`packaging/AppDir/claude-desktop.desktop`** — `StartupWMClass=claude` (this one file feeds the RPM, DEB, Pacman, and Nix builds; `Icon=claude-desktop` unchanged).
- **`patches/open-url-bridge.js`** — `StartupWMClass=claude` for the AppImage runtime-written entry, plus the missing `Icon=claude-desktop`.
- **`flake.nix`** — `--class=claude` and a corrected comment. Belt-and-suspenders: if a future Electron *does* honor `--class`, `claude` still matches; and it documents the real behavior.

## Verification

Diagnosed with `niri msg windows` (App ID `claude`). Confirmed the icon file is installed and discoverable (`…/share/icons/hicolor/*/apps/claude-desktop.png` on `XDG_DATA_DIRS`). `node --check` on the patch; `nix-instantiate --parse` on the flake. Live-tested by setting `StartupWMClass=claude` in the installed `~/.local` entry on a niri session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)