### PR TITLE
fix(computer-use): address #98 review comments

### DIFF
--- a/stubs/claude-swift.js
+++ b/stubs/claude-swift.js
@@ -556,9 +556,10 @@ function _buildReconPngBase64(w, h) {
 
 function _installReconProxy() {
   const fs = require('fs');
-  const RECON_W = 1920, RECON_H = 1080;
+  const RECON_W = 1920, RECON_H = 1080;           // synthetic "display" size
+  const RECON_IMG_W = 160, RECON_IMG_H = 120;     // actual stand-in image size
   let pngB64;
-  try { pngB64 = _buildReconPngBase64(160, 120); } // gradient → comfortably >1024 bytes
+  try { pngB64 = _buildReconPngBase64(RECON_IMG_W, RECON_IMG_H); } // gradient → comfortably >1024 bytes
   catch (_) { pngB64 = ''; }
 
   let seq = 0;
@@ -578,8 +579,11 @@ function _installReconProxy() {
 
   // Permissive stand-ins keyed by full dotted path — chosen so the orchestrator
   // PROCEEDS (recon §8.6) rather than erroring out.
+  // width/height describe the actual stand-in image (post-downscale dims in the
+  // real contract); displayWidth/Height describe the native display. Keeping them
+  // distinct so the orchestrator's modelX*displayWidth/width mapping is coherent.
   const screenshotObj = () => ({
-    base64: pngB64, width: RECON_W, height: RECON_H,
+    base64: pngB64, width: RECON_IMG_W, height: RECON_IMG_H,
     displayWidth: RECON_W, displayHeight: RECON_H, displayId: 0, originX: 0, originY: 0,
   });
   const standIn = (path) => {

--- a/stubs/computer-use-linux.js
+++ b/stubs/computer-use-linux.js
@@ -256,19 +256,20 @@ function resolveDisplay(displayId) {
 // and the image/jpeg mimeType the orchestrator hardcodes both hold.
 // `geometry` (optional) = { x, y, w, h } in display logical points → grim -g.
 // ---------------------------------------------------------------------------
-let _warnedMultiOutput = false;
+let _multiOutputChecked = false;
 
 async function grimCapture(display, geometry) {
   if (!TOOLS.grim) throw new Error('grim not installed');
   // v1: single output → no `-o`, so grim captures the whole layout. When more
   // than one output exists this can disagree with the per-display geometry we
   // report (displayWidth/Height/origin*) and miscalibrate clicks on secondary
-  // monitors. Warn once rather than fail silently; per-output `-o` targeting +
+  // monitors. Probe once (regardless of count) so describeDisplays() doesn't
+  // run on every capture; warn if multi-output. Per-output `-o` targeting +
   // origin offsets are the multi-output TODO (see file header / coordSpace).
-  if (!_warnedMultiOutput) {
-    const outputs = describeDisplays().length; // enumerate once
+  if (!_multiOutputChecked) {
+    _multiOutputChecked = true;
+    const outputs = describeDisplays().length;
     if (outputs > 1) {
-      _warnedMultiOutput = true;
       log(`WARNING: ${outputs} outputs detected; v1 captures the whole layout ` +
           '(no -o targeting). Screenshot/click coordinates are only reliable on a ' +
           'SINGLE-output setup — multi-output is a TODO.');

--- a/stubs/computer-use-linux.js
+++ b/stubs/computer-use-linux.js
@@ -265,11 +265,14 @@ async function grimCapture(display, geometry) {
   // report (displayWidth/Height/origin*) and miscalibrate clicks on secondary
   // monitors. Warn once rather than fail silently; per-output `-o` targeting +
   // origin offsets are the multi-output TODO (see file header / coordSpace).
-  if (!_warnedMultiOutput && describeDisplays().length > 1) {
-    _warnedMultiOutput = true;
-    log(`WARNING: ${describeDisplays().length} outputs detected; v1 captures the whole ` +
-        'layout (no -o targeting). Screenshot/click coordinates are only reliable on a ' +
-        'SINGLE-output setup — multi-output is a TODO.');
+  if (!_warnedMultiOutput) {
+    const outputs = describeDisplays().length; // enumerate once
+    if (outputs > 1) {
+      _warnedMultiOutput = true;
+      log(`WARNING: ${outputs} outputs detected; v1 captures the whole layout ` +
+          '(no -o targeting). Screenshot/click coordinates are only reliable on a ' +
+          'SINGLE-output setup — multi-output is a TODO.');
+    }
   }
   const args = [];
   if (geometry) {

--- a/stubs/computer-use-linux.js
+++ b/stubs/computer-use-linux.js
@@ -88,7 +88,10 @@ function electron() {
 // ---------------------------------------------------------------------------
 function detectTool(bin) {
   try {
-    execFileSync('which', [bin], { stdio: ['ignore', 'ignore', 'ignore'], timeout: 2000 });
+    // `which` resolves in well under this; the short timeout caps the worst case
+    // so the (load-time, experimental-only) detection can't stall startup for
+    // long on a pathological PATH. 3 tools × 600ms ≈ 1.8s worst case.
+    execFileSync('which', [bin], { stdio: ['ignore', 'ignore', 'ignore'], timeout: 600 });
     return true;
   } catch { return false; }
 }
@@ -253,10 +256,22 @@ function resolveDisplay(displayId) {
 // and the image/jpeg mimeType the orchestrator hardcodes both hold.
 // `geometry` (optional) = { x, y, w, h } in display logical points → grim -g.
 // ---------------------------------------------------------------------------
+let _warnedMultiOutput = false;
+
 async function grimCapture(display, geometry) {
   if (!TOOLS.grim) throw new Error('grim not installed');
+  // v1: single output → no `-o`, so grim captures the whole layout. When more
+  // than one output exists this can disagree with the per-display geometry we
+  // report (displayWidth/Height/origin*) and miscalibrate clicks on secondary
+  // monitors. Warn once rather than fail silently; per-output `-o` targeting +
+  // origin offsets are the multi-output TODO (see file header / coordSpace).
+  if (!_warnedMultiOutput && describeDisplays().length > 1) {
+    _warnedMultiOutput = true;
+    log(`WARNING: ${describeDisplays().length} outputs detected; v1 captures the whole ` +
+        'layout (no -o targeting). Screenshot/click coordinates are only reliable on a ' +
+        'SINGLE-output setup — multi-output is a TODO.');
+  }
   const args = [];
-  // v1: single output → no `-o`. Multi-output TODO: args.push('-o', outputName).
   if (geometry) {
     args.push('-g', `${Math.round(geometry.x)},${Math.round(geometry.y)} ${Math.round(geometry.w)}x${Math.round(geometry.h)}`);
   }


### PR DESCRIPTION
Addresses the three Copilot review comments on the dev→main promotion PR (#98), all on the experimental, default-off computer-use code. Merging into `dev` so #98 picks them up.

| Comment | Fix |
|---|---|
| `stubs/claude-swift.js` — recon stand-in is 160×120 but reports `width/height` 1920×1080, skewing the model→click mapping during recon | report `width/height` = actual image size (160×120), keep `displayWidth/displayHeight` = display size (1920×1080) — matches the real contract (downscaled-image dims vs native dims) |
| `stubs/computer-use-linux.js` — load-time tool detection (`execFileSync which`, 2000 ms × 3) can stall the main process up to ~6 s | lower per-tool timeout to **600 ms** (`which` resolves far faster); worst case ~1.8 s, and only on the experimental path |
| `stubs/computer-use-linux.js` — `grimCapture()` doesn't target `-o`, so on multi-monitor the screenshot may not match the selected `displayId`/geometry | **warn once** when >1 output is detected (v1 captures the whole layout; per-output `-o` + origin offsets remain the documented multi-output TODO). Chose a warning over unreliable `display.label → -o` mapping, which could silently capture the wrong output |

## Validation

`node --check` on both stubs; `--selftest` passes (incl. failure-path cases + live grim capture); recon proxy now reports `160×120` image with `1920×1080` display, base64 ≥ 1024 bytes. No behavior change to the default build — `computerUse` stays `null` without the flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)